### PR TITLE
bugfix/WAR-1203: Unable to use the environment variable with dots in it

### DIFF
--- a/warrior/Framework/Utils/data_Utils.py
+++ b/warrior/Framework/Utils/data_Utils.py
@@ -1338,9 +1338,9 @@ def get_filepath_from_system(datafile, system_name, *args):
 
 
 def get_var_by_string_prefix(string):
-    if string.startswith("ENV"):
+    if string.startswith("ENV."):
         return os.environ[string.split('.', 1)[1]]
-    if string.startswith("REPO"):
+    if string.startswith("REPO."):
         keys = string.split('.')
         val = get_object_from_datarepository(keys[1])
         for key in keys[2:]:

--- a/warrior/Framework/Utils/data_Utils.py
+++ b/warrior/Framework/Utils/data_Utils.py
@@ -1338,9 +1338,9 @@ def get_filepath_from_system(datafile, system_name, *args):
 
 
 def get_var_by_string_prefix(string):
-    if "ENV" in string:
+    if string.startswith("ENV"):
         return os.environ[string.split('.', 1)[1]]
-    if "REPO" in string:
+    if string.startswith("REPO"):
         keys = string.split('.')
         val = get_object_from_datarepository(keys[1])
         for key in keys[2:]:

--- a/warrior/Framework/Utils/data_Utils.py
+++ b/warrior/Framework/Utils/data_Utils.py
@@ -1339,7 +1339,7 @@ def get_filepath_from_system(datafile, system_name, *args):
 
 def get_var_by_string_prefix(string):
     if "ENV" in string:
-        return os.environ[string.split('.')[1]]
+        return os.environ[string.split('.', 1)[1]]
     if "REPO" in string:
         keys = string.split('.')
         val = get_object_from_datarepository(keys[1])


### PR DESCRIPTION
Issue: Unable to use the environment variable with dots in it
Reason: For ENV substitution, 'get_var_by_string_prefix' method just uses the second part of a string after splitting it using '.'(dot).
Solution:  Use maxsplit argument to get the string comes after first occurrence of '.'(dot).