### PR TITLE
WAR-1150: improve convert_string_dict function 

### DIFF
--- a/warrior/Framework/Utils/dict_Utils.py
+++ b/warrior/Framework/Utils/dict_Utils.py
@@ -40,7 +40,9 @@ def convert_string_to_dict(element, key_value_pair_sep=";", key_value_sep="="):
             element[i] = element[i].strip()
             if element[i] is not None and element[i] is not False \
                     and element[i] != "":
-                element[i] = element[i].split(key_value_sep)
+                # element[i] will be split into 2 based on the key_value_sep
+                # element[i] will be split on the first occurance of delimiter
+                element[i] = element[i].split(key_value_sep, 1)
                 for j in range(0, len(element[i])):
                     element[i][j] = element[i][j].strip()
                 if len(element[i]) < 2:


### PR DESCRIPTION
To handle cases where the /key_value_seperator/ delimiter is also present in the /value/ part of the string.

Cookie is of the format key=value in string type.
but the value has many "=". We convert the string to dict based on delimiter"=" and it fails for all scenarios where we have "=" part of value.
Discussed with developers on possibility of character in value to choose delimiter. Suggestion was to use ":" as delimiter. So i have added a line to replace the 1st occurrence of "=" with ":"
Only The first occurrence is replaced because for cookies we are not expecting multiple values and is always one value.
Tested with users testcase as well as with our own rest tests in DemoTests.
Demo test results and regression results are available in the jira ticket.