### PR TITLE
war 1297: Env Variable keyword not working for URL that has more than one

### DIFF
--- a/warrior/Framework/Utils/data_Utils.py
+++ b/warrior/Framework/Utils/data_Utils.py
@@ -1394,7 +1394,7 @@ def subst_var_patterns_by_prefix(raw_value, start_pattern="${",
             if len(extracted_var) > 0:
                 for string in extracted_var:
                     try:
-                        if isinstance(raw_value[k], str):
+                        if isinstance(raw_value[k], (str, unicode):
                             raw_value[k] = raw_value[k].replace(
                                 start_pattern+string+end_pattern,
                                 get_var_by_string_prefix(string))

--- a/warrior/Framework/Utils/data_Utils.py
+++ b/warrior/Framework/Utils/data_Utils.py
@@ -1394,7 +1394,7 @@ def subst_var_patterns_by_prefix(raw_value, start_pattern="${",
             if len(extracted_var) > 0:
                 for string in extracted_var:
                     try:
-                        if isinstance(raw_value[k], (str, unicode):
+                        if isinstance(raw_value[k], (str, unicode)):
                             raw_value[k] = raw_value[k].replace(
                                 start_pattern+string+end_pattern,
                                 get_var_by_string_prefix(string))


### PR DESCRIPTION
Current behaviour : 
If we have two ENV variable defined "<url>{ENV.IPADD}:8443//${ENV.R_NODEID}</url>". While replacing the first variable IPADD the replace function changes the string to unicode as the value is pulled from JSON ENV_variable file. But only string are accepted in the current code. So whenever we have more than one ENV or REPO variables defined and if the value of anyof these variables is unicode. The second substitution does not happen. Unicode values are introduced whenever we load the values for the variables from any json files. 

Change : Adding "unicode" type along with string. 