### PR TITLE
WAR-1319 : Case details are not printed as part of Warrior execution summary

### DIFF
--- a/warrior/WarriorCore/Classes/execution_summary_class.py
+++ b/warrior/WarriorCore/Classes/execution_summary_class.py
@@ -61,7 +61,8 @@ class ExecutionSummary():
                 case_result_dir_with_tc_name = testcase_details.get('resultsdir')
                 if case_result_dir_with_tc_name is not None:
                     case_result_dir = os.path.dirname(case_result_dir_with_tc_name)
-                    if suite_result_dir == case_result_dir:
+                    # suite junit element will not have resultsdir attrib for case execution
+                    if suite_result_dir is None or suite_result_dir == case_result_dir:
                         print_info("{0:10}{1:50}{2:10}{3:30}".format("Testcase", testcase_name,
                                                                      testcase_status,
                                                                      testcase_location))

--- a/warrior/WarriorCore/Classes/html_results_class.py
+++ b/warrior/WarriorCore/Classes/html_results_class.py
@@ -435,14 +435,15 @@ class WarriorHtmlResults():
         html_results_path = results_dir + os.sep + html_filename
         return html_results_path
 
-    def output_html(self):
+    def output_html(self, print_summary=True):
         """Output the html file and its required
         script/stylesheets/bootstrap files to results folder """
         tree = ET.ElementTree(self.html_root)
         tree.write(self.html_results_path)
-        print_info("++++ Results Summary ++++")
-        print_info("Open the Results summary file given below in a browser to "\
-                   "view results summary for this execution")
-        print_info("Results sumary file: {0}".format(self.html_results_path))
-        print_info("+++++++++++++++++++++++++")
-        
+        if print_summary is True:
+            print_info("++++ Results Summary ++++")
+            print_info("Open the Results summary file given below in a browser"
+                       " to view results summary for this execution")
+            print_info("Results sumary file: {0}".format(self.html_results_path))
+            print_info("+++++++++++++++++++++++++")
+

--- a/warrior/WarriorCore/Classes/junit_class.py
+++ b/warrior/WarriorCore/Classes/junit_class.py
@@ -32,6 +32,7 @@ class Junit(object):
         self.root.append(properties)
 
     def init_arg(self, **kwargs):
+        """ Initialize arguments """
         default_keys = ["errors", "failures", "skipped", "time", "passes"]
         result = {}
         for default_key in default_keys: 
@@ -41,6 +42,7 @@ class Junit(object):
         return result
 
     def create_testsuite(self, location, **kwargs):
+        """ Create a suite xml element and attach it to root element """
         testsuite = self.create_element("testsuite", tests="0", **self.init_arg(**kwargs))
         properties = self.create_element("properties")
         testsuite.append(properties)
@@ -51,6 +53,7 @@ class Junit(object):
         self.root.append(testsuite)
 
     def create_testcase(self, location, timestamp, ts_timestamp, name, classname="customTestsuite_independant_testcase_execution", **kwargs):
+        """ Create a case xml element and attach it to suite element """
         if self.root.find("testsuite") is None:
             self.update_attr("timestamp", timestamp, "pj", "0")
             self.create_testsuite(location=location, name=classname, timestamp=timestamp, **self.init_arg(**kwargs))
@@ -75,24 +78,28 @@ class Junit(object):
         return elem
 
     def get_family_with_timestamp(self, timestamp):
+        """ Get case, suite & root element based on the timestamp value """
         for testsuite in list(self.root):
             for testcase in list(testsuite):
                 if testcase.get("timestamp") == timestamp:
                     return [testcase, testsuite, self.root]
 
     def get_tc_with_timestamp(self, timestamp):
+        """ Get case element based on the timestamp value """
         for testsuite in list(self.root):
             for testcase in list(testsuite):
                 if testcase.get("timestamp") == timestamp:
                     return testcase
 
     def get_ts_with_timestamp(self, timestamp):
+        """ Get suite element based on the timestamp value """
         for testsuite in list(self.root):
             if testsuite.get("timestamp") == timestamp:
                 return testsuite
 
     def add_keyword_result(self, tc_timestamp, step_num, kw_name, status, kw_timestamp, duration,
                            resultfile, impact, onerror):
+        """ Add keyword results to junit object """
         if str(status).lower() == "true":
             status = "PASS"
         elif str(status).lower() == "false":
@@ -102,6 +109,7 @@ class Junit(object):
         self.add_property(name=kw_name, value="KEYWORD_DISCARD", elem_type = "kw", timestamp=tc_timestamp, keyword_items=keyword_items)
 
     def add_testcase_message(self, timestamp, status):
+        """ Add a message element for fail/error/skip cases """
         elem = self.get_tc_with_timestamp(timestamp)
         if elem is None:
             elem = self.get_ts_with_timestamp(timestamp)
@@ -118,6 +126,7 @@ class Junit(object):
             self.create_element("property", {"name":"requirement", "value":requirement}))
 
     def add_property(self, name, value, elem_type, timestamp, **kwargs):
+        """ Add a new property to properties element """
         if elem_type == "pj":
             elem = self.root
         elif elem_type == "ts":
@@ -143,6 +152,7 @@ class Junit(object):
             "property", {"name":"location", "value":location}))
 
     def update_count(self, attr, value, elem_type, timestamp="0"):
+        """ Increment the attribute count by given value  """
         if elem_type == "pj":
             elem = self.root
         elif elem_type == "ts":
@@ -161,6 +171,7 @@ class Junit(object):
             elem.set(attr, str(int(elem.get(attr)) + int(value)))
 
     def update_attr(self, attr, value, elem_type, timestamp):
+        """ Set the attribute value """
         if elem_type == "pj":
             elem = self.root
         elif elem_type == "ts":

--- a/warrior/WarriorCore/Classes/junit_class.py
+++ b/warrior/WarriorCore/Classes/junit_class.py
@@ -183,11 +183,11 @@ class Junit(object):
 
         elem.set(attr, value)
 
-    def _junit_to_html(self, junit_file):
+    def _junit_to_html(self, junit_file, print_summary=True):
         """ Convert junit file to html"""
         html_result_obj = WarriorHtmlResults(junit_file)
         html_result_obj.html_from_junit()
-        html_result_obj.output_html()
+        html_result_obj.output_html(print_summary)
 
     def output_junit(self, path, print_summary=True):
         """output the actual file
@@ -202,4 +202,4 @@ class Junit(object):
             summary_obj.print_result_in_console(fpath)
         print("\n")
 
-        self._junit_to_html(fpath)
+        self._junit_to_html(fpath, print_summary)

--- a/warrior/WarriorCore/Classes/junit_class.py
+++ b/warrior/WarriorCore/Classes/junit_class.py
@@ -200,6 +200,6 @@ class Junit(object):
         if print_summary is True:
             summary_obj = ExecutionSummary(fpath)
             summary_obj.print_result_in_console(fpath)
-        print("\n")
+        print_info("\n")
 
         self._junit_to_html(fpath, print_summary)

--- a/warrior/WarriorCore/step_driver.py
+++ b/warrior/WarriorCore/step_driver.py
@@ -185,12 +185,12 @@ def execute_step(step, step_num, data_repository, system_name, parallel, queue):
                 step, 'onError', 'value')
     testcase_error_action = data_repository['wt_def_on_error_action']
     step_onError_action = step_onError_action if step_onError_action else testcase_error_action
-    if step_onError_action.upper() == "GOTO" and step_goto_value == False:
+    if step_onError_action.upper() == "GOTO" and step_goto_value is False:
         step_goto_value = data_repository['wt_def_on_error_value']
     onerror = step_onError_action.upper()
     if step_goto_value is not False and step_goto_value is not None:
         onerror = onerror + " step " + step_goto_value
-    if keyword_status == False and step_onError_action and step_onError_action.upper() == 'ABORT_AS_ERROR':
+    if keyword_status is False and step_onError_action and step_onError_action.upper() == 'ABORT_AS_ERROR':
         print_info(
             "Keyword status will be marked as ERROR as onError action is set to 'abort_as_error'")
         keyword_status = "ERROR"

--- a/warrior/WarriorCore/step_driver.py
+++ b/warrior/WarriorCore/step_driver.py
@@ -174,7 +174,7 @@ def execute_step(step, step_num, data_repository, system_name, parallel, queue):
         exec_type_onerror = True
         print_debug("Action is {0}".format(action))
 
-    print("\n")
+    print_info("\n")
     print_info("*** Keyword status ***")
     step_goto_value = False
     step_onError_action = Utils.xml_Utils.get_attributevalue_from_directchildnode(
@@ -221,7 +221,7 @@ def execute_step(step, step_num, data_repository, system_name, parallel, queue):
             data_repository['step-%s_exception' % step_num]
         Utils.testcase_Utils.pNote_level(msg, "debug", "kw", ptc=False)
     # time.sleep(1)
-    print("\n")
+    print_info("\n")
     kw_end_time = Utils.datetime_utils.get_current_timestamp()
     kw_duration = Utils.datetime_utils.get_time_delta(kw_start_time)
     hms = Utils.datetime_utils.get_hms_for_seconds(kw_duration)

--- a/warrior/WarriorCore/step_driver.py
+++ b/warrior/WarriorCore/step_driver.py
@@ -250,21 +250,6 @@ def execute_step(step, step_num, data_repository, system_name, parallel, queue):
         tc_junit_object.output_junit(data_repository['wp_results_execdir'],
                                      print_summary=False)
 
-    # Get the type of the file being executed by Warrior: Case/Suite/Project
-    war_file_type = data_repository.get('war_file_type')
-    if war_file_type == "Case":
-        # Create and replace existing Case junit file for each step
-        tc_junit_object.output_junit(data_repository['wt_resultsdir'],
-                                     print_summary=False)
-    elif war_file_type == "Suite":
-        # Create and replace existing Suite junit file for each step
-        tc_junit_object.output_junit(data_repository['wt_results_execdir'],
-                                     print_summary=False)
-    elif war_file_type == "Project":
-        # Create and replace existing Project junit file for each step
-        tc_junit_object.output_junit(data_repository['wp_results_execdir'],
-                                     print_summary=False)
-
     if parallel is True:
         # put result into multiprocessing queue and later retrieve in
         # corresponding driver


### PR DESCRIPTION
Issues fixed here:
1. Case details are not printed as part of Warrior execution summary : added one more condition in 'suite_summary' method to print summary when executing a case
2. Results summary is being printed for case steps : added an optional parameter to print results summary & it should be set to False when called after step execution

How to test - Run any Warrior case and check if the 'Execution Summary' has the status of case in it.
Regression results are in Jira ticket.