### PR TITLE
WAR-1003: Adding python version details alongside warrior details

### DIFF
--- a/warrior/WarriorCore/framework_detail.py
+++ b/warrior/WarriorCore/framework_detail.py
@@ -32,7 +32,6 @@ def warrior_banner():
     print_notype(r"    \ V  V / ___ \|  _ <|  _ < | | |_| |  _ <   ")
     time.sleep(0.10)
     print_notype(r"     \_/\_/_/   \_\_| \_\_| \_\___\___/|_| \_\  ")
-    print "\n"
 
 def warrior_framework_details():
     """This gets framework details such the executing framework path, release

--- a/warrior/WarriorCore/framework_detail.py
+++ b/warrior/WarriorCore/framework_detail.py
@@ -11,36 +11,33 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 
-"""This file is used to define the framwork notype and retrieve the release,\
-   version from licence or release notes.
-"""
 import time
 import os
-import platform 
-import re  
-from Framework.Utils.print_Utils import print_info, print_notype
+import platform
+import re
+from Framework.Utils.print_Utils import print_info
 from Framework.Utils import file_Utils
 from Framework.Utils.testcase_Utils import pNote
 
 
 def warrior_banner():
-    """This prints banner of warrior. The font is standard 
+    """This prints banner of warrior. The font is standard
     """
 
-    print(" __        ___    ____  ____  ___ ___  ____  ")
+    print " __        ___    ____  ____  ___ ___  ____  "
     time.sleep(0.10)
-    print(" \ \      / / \  |  _ \|  _ \|_ _/ _ \|  _ \  ")
+    print " \ \      / / \  |  _ \|  _ \|_ _/ _ \|  _ \  "
     time.sleep(0.10)
-    print("  \ \ /\ / / _ \ | |_) | |_) || | | | | |_) |  ")
+    print "  \ \ /\ / / _ \ | |_) | |_) || | | | | |_) |  "
     time.sleep(0.10)
-    print("   \ V  V / ___ \|  _ <|  _ < | | |_| |  _ <   ")
+    print "   \ V  V / ___ \|  _ <|  _ < | | |_| |  _ <   "
     time.sleep(0.10)
-    print("    \_/\_/_/   \_\_| \_\_| \_\___\___/|_| \_\  ")
+    print "    \_/\_/_/   \_\_| \_\_| \_\___\___/|_| \_\  "
     print "\n"
 
 def warrior_framework_details():
-    """This gets framework details such the executing framework path, release 
-        & version details. 
+    """This gets framework details such the executing framework path, release
+        & version details.
     """
     #The logic uses relative file path to locate Warrior framework and its\
     # release notes.Assumes the relative structure remains constant.
@@ -50,24 +47,27 @@ def warrior_framework_details():
     version_file = os.path.join(version_file_path, "version.txt")
     version_file_exists = file_Utils.fileExists(version_file)
     if version_file_exists:
-        release_notes =  open(version_file, "r")
+        release_notes = open(version_file, "r")
         for line in release_notes:
             line = line.strip()
-            #pattern matching Release:<>  
-            if (re.match('(Release.*):(.*)', line)):
-                m = re.match(r'(Release.*):(.*)', line)
-                release = m.group(2)
+            #pattern matching Release:<>
+            if re.match('(Release.*):(.*)', line):
+                match = re.match(r'(Release.*):(.*)', line)
+                release = match.group(2)
             #pattern matching Version:<>
-            if (re.match('(Version.*):(.*)', line)):
-                m = re.match(r'(Version.*):(.*)', line)
-                version = m.group(2)
+            if re.match('(Version.*):(.*)', line):
+                match = re.match(r'(Version.*):(.*)', line)
+                version = match.group(2)
     if release and version and version_file_path:
-        pNote("========================== WARRIOR FRAMEWORK DETAILS ==========================", 'notype')
+        pNote("========================== WARRIOR FRAMEWORK DETAILS ==========================",
+              'notype')
         print_info('The Warrior framework used is {0}'.format(version_file_path))
         print_info('The Warrior framework Release is{0}'.format(release))
         print_info('The Warrior framework version is{0}'.format(version))
-        print_info('The Warrior framework is running on python version {0}'.format(platform.python_version()))
-        pNote("========================== WARRIOR FRAMEWORK DETAILS ==========================", 'notype')
+        print_info('The Warrior framework is running on python version {0}'.
+                   format(platform.python_version()))
+        pNote("========================== WARRIOR FRAMEWORK DETAILS ==========================",
+              'notype')
 
     #Sleep for the user to view the console for a second on the framework detail
     time.sleep(2)

--- a/warrior/WarriorCore/framework_detail.py
+++ b/warrior/WarriorCore/framework_detail.py
@@ -14,13 +14,10 @@ limitations under the License.
 """This file is used to define the framwork notype and retrieve the release,\
    version from licence or release notes.
 """
-from datetime import datetime, timedelta
 import time
 import os
-import sys
+import platform 
 import re  
-import platform
-import subprocess
 from Framework.Utils.print_Utils import print_info, print_notype
 from Framework.Utils import file_Utils
 from Framework.Utils.testcase_Utils import pNote
@@ -69,6 +66,7 @@ def warrior_framework_details():
         print_info('The Warrior framework used is {0}'.format(version_file_path))
         print_info('The Warrior framework Release is{0}'.format(release))
         print_info('The Warrior framework version is{0}'.format(version))
+        print_info('The Warrior framework is running on python version {0}'.format(platform.python_version()))
         pNote("========================== WARRIOR FRAMEWORK DETAILS ==========================", 'notype')
 
     #Sleep for the user to view the console for a second on the framework detail

--- a/warrior/WarriorCore/framework_detail.py
+++ b/warrior/WarriorCore/framework_detail.py
@@ -60,10 +60,10 @@ def warrior_framework_details():
         pNote("========================== WARRIOR FRAMEWORK DETAILS ==========================",
               'notype')
         print_info('The Warrior framework used is {0}'.format(version_file_path))
-        print_info('The Warrior framework Release is{0}'.format(release))
+        print_info('The Warrior framework Release is{0d}'.format(release))
         print_info('The Warrior framework version is{0}'.format(version))
-        print_info('The Warrior framework is running on python version {0}'.
-                   format(platform.python_version()))
+        print_info('The Warrior framework running on python version: {0} with OS: {1}'.
+                   format(platform.python_version(), platform.platform()))
         pNote("========================== WARRIOR FRAMEWORK DETAILS ==========================",
               'notype')
 

--- a/warrior/WarriorCore/framework_detail.py
+++ b/warrior/WarriorCore/framework_detail.py
@@ -60,7 +60,7 @@ def warrior_framework_details():
         pNote("========================== WARRIOR FRAMEWORK DETAILS ==========================",
               'notype')
         print_info('The Warrior framework used is {0}'.format(version_file_path))
-        print_info('The Warrior framework Release is{0d}'.format(release))
+        print_info('The Warrior framework Release is{0}'.format(release))
         print_info('The Warrior framework version is{0}'.format(version))
         print_info('The Warrior framework running on python version: {0} with OS: {1}'.
                    format(platform.python_version(), platform.platform()))

--- a/warrior/WarriorCore/framework_detail.py
+++ b/warrior/WarriorCore/framework_detail.py
@@ -15,7 +15,7 @@ import time
 import os
 import platform
 import re
-from Framework.Utils.print_Utils import print_info
+from Framework.Utils.print_Utils import print_info, print_notype
 from Framework.Utils import file_Utils
 from Framework.Utils.testcase_Utils import pNote
 
@@ -23,16 +23,15 @@ from Framework.Utils.testcase_Utils import pNote
 def warrior_banner():
     """This prints banner of warrior. The font is standard
     """
-
-    print " __        ___    ____  ____  ___ ___  ____  "
+    print_notype("  __        ___    ____  ____  ___ ___  ____  ")
     time.sleep(0.10)
-    print " \ \      / / \  |  _ \|  _ \|_ _/ _ \|  _ \  "
+    print_notype(r"  \ \      / / \  |  _ \|  _ \|_ _/ _ \|  _ \  ")
     time.sleep(0.10)
-    print "  \ \ /\ / / _ \ | |_) | |_) || | | | | |_) |  "
+    print_notype(r"   \ \ /\ / / _ \ | |_) | |_) || | | | | |_) |  ")
     time.sleep(0.10)
-    print "   \ V  V / ___ \|  _ <|  _ < | | |_| |  _ <   "
+    print_notype(r"    \ V  V / ___ \|  _ <|  _ < | | |_| |  _ <   ")
     time.sleep(0.10)
-    print "    \_/\_/_/   \_\_| \_\_| \_\___\___/|_| \_\  "
+    print_notype(r"     \_/\_/_/   \_\_| \_\_| \_\___\___/|_| \_\  ")
     print "\n"
 
 def warrior_framework_details():


### PR DESCRIPTION
No specific Tests required for the pull request.

Current change is adding the Python version in logs to inform/help users know the underlying python version. This is important when users try to replicate the same results under different environment. It is important to factor the python version too, while trying to replicate same results across platforms. 

The bold one below is the new addition

 ======================== WARRIOR FRAMEWORK DETAILS ========================== 
-I- The Warrior framework used is /home/hsudarsa/github/python_version/warriorframework
-I- The Warrior framework Release is Ninja
-I- The Warrior framework version is warrior-3.2.0
**-I- The Warrior framework is running on python version 2.7.12**
======================== WARRIOR FRAMEWORK DETAILS ========================== 
