### PR TITLE
WAR-1133 : read requirements file to install dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+jira==1.0.3
+lxml==3.3.3
+ncclient==0.4.6
+paramiko==1.16.0
+pexpect==4.2
+pysnmp==4.3.2
+requests==2.9.1
+selenium==2.48.0
+xlrd==1.0.0
+cloudshell-automation-api==7.1.0.34

--- a/warhorn/default_config.xml
+++ b/warhorn/default_config.xml
@@ -3,7 +3,7 @@
 <!-- To read full documentation for this file, please refer to user_generated/config_sample.xml -->
 
 <data>
-    <warhorn name="Warhorn">
+    <warhorn name="Warhorn" dependency_filepath="Provide filepath, where version details for packages below are defined. By default the versions defined in requirements.txt at the base directory would be used">
         <dependency name="jira" install="no" user="no"/>
         <dependency name="lxml" install="yes" user="no"/>
         <dependency name="ncclient" install="no" user="no"/>

--- a/warhorn/source/utils.py
+++ b/warhorn/source/utils.py
@@ -548,29 +548,34 @@ def get_relative_path(*args):
     return path
 
 
-def get_dict_with_versions():
-    """ This function carries the name and version of the depndencies
+def get_dict_with_versions(filepath, logfile, print_log_name):
+    """ This function reads the requirement.txt file at base directory and updates the version dict
+    with appropriate key(package) value(version)
 
     :Returns:
 
     1. versions (dict) = Dictionary with name as Key and version as value
+    for example:
+    a. if requirements.txt has jira<=1.1.1.1, warhorn will install jira with version 1.1.1.1
+    b. if requirements.txt has jira>=1.1.1.1, warhorn will install jira with version 1.1.1.1
+    c. if requirements.txt has jira==1.1.1.1, warhorn will install jira with version 1.1.1.1
+    d. if requirements.txt has jira<<1.1.1.1, warhorn wont install jira citing corruption in
+    requirements.txt file
     """
-    versions = {'jira': '', 'lxml': '', 'ncclient': '',
-                'paramiko': '', 'pexpect': '', 'pysnmp': '',
-                'requests': '', 'selenium': '', 'xlrd': '',
-                'cloudshell-automation-api': ''}
-
-    with open('../requirements.txt', 'r') as f:
-        for line in f:
-            dependancy_list = line.split("=")
-            if len(dependancy_list) == 3:
-                versions[dependancy_list[0]] = dependancy_list[2].rstrip()
-            elif len(dependancy_list) == 2:
-                versions[dependancy_list[0][:-1]] = dependancy_list[1].rstrip()
-            else:
-                print_error("Please do not alter requirements.txt")
-    return versions
-
+    versions = {'jira': '', 'lxml': '', 'ncclient': '', 'paramiko': '', 'pexpect': '', 'pysnmp': '',
+                'requests': '', 'selenium': '', 'xlrd': '', 'cloudshell-automation-api': ''}
+    if not os.path.exists(filepath):
+        print_warning("The dependancy_filepath {0} does not exist, falling back to default file "
+                    "requirements.txt at base directory".format(filepath), logfile, print_log_name)
+        filepath = "../requirements.txt"
+    with open(filepath, 'r') as requirements:
+        for line in requirements:
+            dependency_list = line.split("=")
+            if len(dependency_list) == 3:
+                versions[dependency_list[0]] = dependency_list[2].rstrip()
+            elif len(dependency_list) == 2:
+                versions[dependency_list[0][:-1]] = dependency_list[1].rstrip()
+    return versions, os.path.abspath(filepath)
 
 def install_depen(dependency, dependency_name, logfile, print_log_name,
                   user=None):
@@ -651,9 +656,9 @@ def get_dependencies(logfile, print_log_name, config_file_name):
     1. install_reqs(list[str]) = a list of dependencies that the user
     has asked warhorn.py to install.
     install_reqs = [<dep_name>==<version>, <dep_name>==<version>]
-
     """
     node = get_node(config_file_name, 'warhorn')
+    dependency_filepath = node.attrib['dependency_filepath']
     if node is False:
         print_error("Warhorn tag not found! Proceeding with the installation "
                     "without installing any of the recommended "
@@ -661,35 +666,32 @@ def get_dependencies(logfile, print_log_name, config_file_name):
         setDone(1)
     else:
         dependencies = get_firstlevel_children(node, "dependency")
-        versions = get_dict_with_versions()
+        versions, valid_dependency_file = get_dict_with_versions(dependency_filepath, logfile, print_log_name)
         for dependency in dependencies:
             if 'install' in dependency.attrib:
-                if dependency.attrib["install"] == "yes":
-                    print_info("Warhorn will try to install " +
-                               dependency.attrib["name"] +
-                               " as it was set to 'yes' in the .xml file",
-                               logfile, print_log_name)
-                    if ('user' in dependency.attrib and
-                            dependency.attrib["user"] == "yes"):
+                if dependency.attrib["install"] == "yes" and \
+                        versions.get(dependency.attrib["name"]):
+                    print_info("Warhorn will try to install " + dependency.attrib["name"] +
+                               " as it was set to 'yes' in the .xml file", logfile, print_log_name)
+                    if 'user' in dependency.attrib and dependency.attrib["user"] == "yes":
                         install_depen(dependency.attrib["name"] + "==" +
                                       versions.get(dependency.attrib["name"]),
-                                      dependency.attrib["name"], logfile,
-                                      print_log_name, True)
+                                      dependency.attrib["name"], logfile, print_log_name, True)
                     else:
                         install_depen(dependency.attrib["name"] + "==" +
                                       versions.get(dependency.attrib["name"]),
                                       dependency.attrib["name"], logfile,
                                       print_log_name)
                 elif dependency.attrib["install"] == "no":
-                    print_info("Warhorn will not install " +
-                               dependency.attrib["name"] +
-                               " as it was set to 'no' in the .xml file.",
-                               logfile, print_log_name)
+                    print_info("Warhorn will not install " + dependency.attrib["name"] +
+                               " as it was set to 'no' in the .xml file.", logfile, print_log_name)
+                elif not versions.get(dependency.attrib["name"]):
+                    print_error("The {0} file doesn't have valid version for package:"
+                                .format(valid_dependency_file)+
+                                dependency.attrib["name"], logfile, print_log_name )
                 else:
-                    print_error("Warhorn will not install " +
-                                dependency.attrib["name"] +
-                                " as the 'install' attribute in the .xml file "
-                                "was left blank.",
+                    print_error("Warhorn will not install " + dependency.attrib["name"] +
+                                " as the 'install' attribute in the .xml file was left blank.",
                                 logfile, print_log_name)
                     setDone(1)
             else:

--- a/warhorn/source/utils.py
+++ b/warhorn/source/utils.py
@@ -555,10 +555,20 @@ def get_dict_with_versions():
 
     1. versions (dict) = Dictionary with name as Key and version as value
     """
-    versions = {'jira': '1.0.3', 'lxml': '3.3.3', 'ncclient': '0.4.6',
-                'paramiko': '1.16.0', 'pexpect': '4.2', 'pysnmp': '4.3.2',
-                'requests': '2.9.1', 'selenium': '2.48.0', 'xlrd': '1.0.0',
-                'cloudshell-automation-api':'7.1.0.34'}
+    versions = {'jira': '', 'lxml': '', 'ncclient': '',
+                'paramiko': '', 'pexpect': '', 'pysnmp': '',
+                'requests': '', 'selenium': '', 'xlrd': '',
+                'cloudshell-automation-api': ''}
+
+    with open('../requirements.txt', 'r') as f:
+        for line in f:
+            dependancy_list = line.split("=")
+            if len(dependancy_list) == 3:
+                versions[dependancy_list[0]] = dependancy_list[2].rstrip()
+            elif len(dependancy_list) == 2:
+                versions[dependancy_list[0][:-1]] = dependancy_list[1].rstrip()
+            else:
+                print_error("Please do not alter requirements.txt")
     return versions
 
 


### PR DESCRIPTION
Read the requirement file and add dependencies. 
Allow the user to provide their own requirement file, so that our requirement file is not edited.

Test : 1
Run warhorn.py after changing the values in requirement file and see if they are installed properly.
Run warhorn.py after deleting a key&value pair and see if the error is handled appropriately.
Provide another requirement file and run warhorn to see if warhorn ignores requirement.txt and takes the user defined file.
Provide a file which does not exist, see if warhorn falls back to default requirement.txt file. 
One can install all dependancy at one go through pip -r requirement.txt