### PR TITLE
WAR-1405 : Travis- Ignore deleted files for pylint check

### DIFF
--- a/wftests/ci/pylint.sh
+++ b/wftests/ci/pylint.sh
@@ -13,7 +13,7 @@ git add .
 
 git branch
 # Displaying what .py files have changed
-filelist=$(git --no-pager diff "${TRAVIS_BRANCH}" --name-only | grep ".py$")
+filelist=$(git --no-pager diff "${TRAVIS_BRANCH}" --name-only --diff-filter=d | grep ".py$")
 if [[ "$filelist" ]]; then
     echo "$filelist" > filelist.txt
     python ../warriorframework/wftests/ci/pylint_checker.py filelist.txt .pylintrc "${TRAVIS_BRANCH}" "${TRAVIS_PULL_REQUEST_BRANCH}"


### PR DESCRIPTION
The change is for ignoring the the files deleted in the PR target branch during pylint check
Adding 'diff-filter=d' option in the git command(we use to get the diff files) will ignore the deleted files.