### PR TITLE
WAR-1450: Print the 'expected result' before the test case starts

### DIFF
--- a/warrior/WarriorCore/testcase_driver.py
+++ b/warrior/WarriorCore/testcase_driver.py
@@ -42,6 +42,8 @@ def get_testcase_details(testcase_filepath, data_repository, jiraproj):
 
     name = Utils.xml_Utils.getChildTextbyParentTag(testcase_filepath, 'Details', 'Name')
     title = Utils.xml_Utils.getChildTextbyParentTag(testcase_filepath, 'Details', 'Title')
+    expResults = Utils.xml_Utils.getChildTextbyParentTag(testcase_filepath,'Details',
+                                                         'ExpectedResults')
     category = Utils.xml_Utils.getChildTextbyParentTag(testcase_filepath, 'Details', 'Category')
     def_on_error_action = Utils.testcase_Utils.get_defonerror_fromxml_file(testcase_filepath)
     def_on_error_value = Utils.xml_Utils.getChildAttributebyParentTag(testcase_filepath, 'Details',
@@ -64,6 +66,9 @@ def get_testcase_details(testcase_filepath, data_repository, jiraproj):
         title = "None"
     else:
         title = str(title).strip()
+
+    if expResults is None or expResults is False:
+        expResults = "None"
 
     if def_on_error_value is None or def_on_error_value is False:
         def_on_error_value = None
@@ -125,7 +130,8 @@ def get_testcase_details(testcase_filepath, data_repository, jiraproj):
     Utils.config_Utils.debug_file(console_logfile)
     # objLogFile = Utils.testcase_Utils.pOpen(logfile)
 
-    to_strip_list = [name, title, category, datafile, data_type, logsdir, resultsdir, defectsdir]
+    to_strip_list = [name, title, category, datafile, data_type, logsdir,
+                     resultsdir, defectsdir, expResults]
     stripped_list = Utils.string_Utils.strip_white_spaces(to_strip_list)
 
     name = stripped_list[0]
@@ -136,6 +142,7 @@ def get_testcase_details(testcase_filepath, data_repository, jiraproj):
     logsdir = stripped_list[5]
     resultsdir = stripped_list[6]
     defectsdir = stripped_list[7]
+    expResults = stripped_list[8]
 
     # Add variables to data_repository
     data_repository['wt_name'] = name
@@ -150,6 +157,7 @@ def get_testcase_details(testcase_filepath, data_repository, jiraproj):
     data_repository['wt_logsdir'] = logsdir
     data_repository['wt_kw_results_dir'] = kw_results_dir
     data_repository['wt_defectsdir'] = defectsdir
+    data_repository['wt_expResults'] = expResults
     # data_repository['wt_logfile'] = objLogFile
     data_repository['wt_operating_system'] = operating_system.upper()
     data_repository['wt_def_on_error_action'] = def_on_error_action.upper()
@@ -365,6 +373,7 @@ def print_testcase_details_to_console(testcase_filepath, data_repository):
     print_info("Logs directory: %s" % data_repository['wt_logsdir'])
     print_info("Defects directory: {0}".format(data_repository["wt_defectsdir"]))
     print_info("Datafile: %s" % data_repository['wt_datafile'])
+    print_info("Expected Results: %s" % data_repository['wt_expResults'])
     report_testcase_requirements(testcase_filepath)
     print_info("================================================================================================")
     time.sleep(2)


### PR DESCRIPTION
Code change(s): Print the value provided in the 'Expected Results' field of a testcase during execution.

How to test: Run any test to see if the value provided in the 'Expected Results' field is being printed in the console along with other testcase details.
Logs: Regression logs are attached in the Jira ticket