### PR TITLE
Add logging support for core apps as an example

### DIFF
--- a/katana/wui/settings.py
+++ b/katana/wui/settings.py
@@ -36,7 +36,6 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'jsonify',
     'wui.core',
     'native.wapp_management',
     'native.wappstore',
@@ -126,3 +125,64 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 DATA_UPLOAD_MAX_MEMORY_SIZE = 10242880
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            #'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
+            'format': '%(levelname)s %(asctime)s %(module)s %(funcName)s %(lineno)d %(message)s'
+        },
+        'simple': {
+            'format': '%(levelname)s %(message)s'
+        },
+    },
+    'handlers': {
+        'file': {
+            'level': 'DEBUG',
+            'class': 'logging.FileHandler',
+            'filename': BASE_DIR + os.sep + 'logs' + os.sep + 'katana.log',
+        },
+        'project_file': {
+            'level': 'DEBUG',
+            'class': 'logging.FileHandler',
+            'filename': BASE_DIR + os.sep + 'logs' + os.sep + 'katana_projects.log',
+            'formatter' : 'verbose',
+        },
+        'suite_file': {
+            'level': 'DEBUG',
+            'class': 'logging.FileHandler',
+            'filename': BASE_DIR + os.sep + 'logs' + os.sep + 'katana_suites.log',
+            'formatter' : 'verbose',
+        },
+        'case_file': {
+            'level': 'DEBUG',
+            'class': 'logging.FileHandler',
+            'filename': BASE_DIR + os.sep + 'logs' + os.sep + 'katana_cases.log',
+            'formatter' : 'verbose',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['file'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'native.projects': {
+            'handlers': ['project_file'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'native.suites': {
+            'handlers': ['suite_file'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'native.cases': {
+            'handlers': ['case_file'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+    },
+}


### PR DESCRIPTION
This adds support for logging from core apps.  
The original branch WAR-1396 is not valid Please use this branch instead . 