### PR TITLE
WAR-1494 Variable substitution process string incorrectly when string doesn't contain end_pattern longer than 1 char

### DIFF
--- a/warrior/Framework/ClassUtils/configuration_element_class.py
+++ b/warrior/Framework/ClassUtils/configuration_element_class.py
@@ -41,8 +41,9 @@ class ConfigurationElement(object):
         :param string:
         :return:
         """
-        # print "pattern of regex:", r".*(" + re.escape(self.start_pat) + r"(.*)" + re.escape(self.end_pat) + r").*"
-        # print "what string it is getting regex", string
+        # Create a regex search object which, when found
+        # contains a group object with the text within the start and end pattern
+        # and another group object with the text and start/end pattern
         return re.search(r".*(" + re.escape(self.start_pat) + r"(.*)" + re.escape(self.end_pat) + r").*", string)
 
     def expand_variables(self, string):

--- a/warrior/Framework/ClassUtils/configuration_element_class.py
+++ b/warrior/Framework/ClassUtils/configuration_element_class.py
@@ -44,7 +44,8 @@ class ConfigurationElement(object):
         # Create a regex search object which, when found
         # contains a group object with the text within the start and end pattern
         # and another group object with the text and start/end pattern
-        return re.search(r".*(" + re.escape(self.start_pat) + r"(.*)" + re.escape(self.end_pat) + r").*", string)
+        text_between_pattern = r"([^" + re.escape(self.end_pat) + r"]*)"
+        return re.search(r".*(" + re.escape(self.start_pat) + text_between_pattern + re.escape(self.end_pat) + r").*", string)
 
     def expand_variables(self, string):
         """
@@ -68,12 +69,11 @@ class ConfigurationElement(object):
         return_value = string
         end_pattern = self.end_pat
         # When end_pat_index == -1, which means end_pattern is not found in the return_value string
-        end_pat_index = return_value.find(end_pattern)
         # Get the regex match object of the substring
         # which looks for text between start and endpattern
-        match = self.__find_match(return_value[:end_pat_index + len(end_pattern)])
+        match = self.__find_match(return_value)
         # Only substitued the string when there is a match
-        while end_pat_index != -1 and match is not None:
+        while match is not None:
             # match.group(2) contains the pre-sub value
             # substitued value is the actual value after parsing the pre-sub value
             substitued_value = self.get_value(match.group(2))
@@ -88,8 +88,7 @@ class ConfigurationElement(object):
                 return_value, self.start_pat, self.end_pat)
 
             # Doing another search for the next value to substitue
-            end_pat_index = return_value.find(end_pattern)
-            match = self.__find_match(return_value[:end_pat_index + len(end_pattern)])
+            match = self.__find_match(return_value)
 
         return return_value
 

--- a/warrior/Framework/ClassUtils/configuration_element_class.py
+++ b/warrior/Framework/ClassUtils/configuration_element_class.py
@@ -41,9 +41,10 @@ class ConfigurationElement(object):
         :param string:
         :return:
         """
-        # Create a regex search object which, when found
-        # contains a group object with the text within the start and end pattern
+        # Create a regex search object which contains
+        # a group object with the text within the start and end pattern
         # and another group object with the text and start/end pattern
+        # if the regex pattern doesn't match with the string, it return None
         text_between_pattern = r"([^" + re.escape(self.end_pat) + r"]*)"
         return re.search(r".*(" + re.escape(self.start_pat) + text_between_pattern + re.escape(self.end_pat) + r").*", string)
 

--- a/warrior/Framework/ClassUtils/configuration_element_class.py
+++ b/warrior/Framework/ClassUtils/configuration_element_class.py
@@ -67,7 +67,6 @@ class ConfigurationElement(object):
         """
         # The string that is currently being processed
         return_value = string
-        end_pattern = self.end_pat
         # When end_pat_index == -1, which means end_pattern is not found in the return_value string
         # Get the regex match object of the substring
         # which looks for text between start and endpattern

--- a/warrior/Framework/ClassUtils/configuration_element_class.py
+++ b/warrior/Framework/ClassUtils/configuration_element_class.py
@@ -66,37 +66,31 @@ class ConfigurationElement(object):
         # The string that is currently being processed
         return_value = string
         end_pattern = self.end_pat
-        # print "end_pattern:", end_pattern
-        # print "string:", string
-        # need to end_pattern if find == -1, which means not found
+        # When end_pat_index == -1, which means end_pattern is not found in the return_value string
         end_pat_index = return_value.find(end_pattern)
-        # print "substring:", return_value[:end_pat_index + len(end_pattern)]
         # Get the regex match object of the substring
         # which looks for text between start and endpattern
         match = self.__find_match(return_value[:end_pat_index + len(end_pattern)])
-        # Have a match
-        if end_pat_index != -1 and match is not None:
-            # print "match:", match
-            while end_pat_index != -1 and match is not None:
-                # match.group(2) contains the pre-sub value
-                substitued_value = self.get_value(match.group(2))
-                # match.group(1) contains the whole string
-                return_value = return_value.replace(match.group(1), substitued_value)
-                # Call other substitute functions
-                return_value = Utils.data_Utils.sub_from_env_var(return_value, self.start_pat, self.end_pat)
-                return_value = Utils.data_Utils.sub_from_data_repo(return_value, self.start_pat, self.end_pat)
+        # Only substitued the string when there is a match
+        while end_pat_index != -1 and match is not None:
+            # match.group(2) contains the pre-sub value
+            # substitued value is the actual value after parsing the pre-sub value
+            substitued_value = self.get_value(match.group(2))
+            # match.group(1) contains start_pattern, pre-sub value and end_pattern
+            # for default pattern, it looks like ${PRESUB_VALUE}
+            # this step replace the pre_sub value
+            return_value = return_value.replace(match.group(1), substitued_value, 1)
+            # Call other substitute functions
+            return_value = Utils.data_Utils.sub_from_env_var(
+                return_value, self.start_pat, self.end_pat)
+            return_value = Utils.data_Utils.sub_from_data_repo(
+                return_value, self.start_pat, self.end_pat)
 
-                end_pat_index = return_value.find(end_pattern)
-                match = self.__find_match(return_value[:end_pat_index + len(end_pattern)])
-                # print "<<< In while loop >>>"
-                # print "return_value:", return_value
-                # print "end_pat_index:", end_pat_index
-                # print "match:", match
-                # print "<<< end while loop >>>"
+            # Doing another search for the next value to substitue
+            end_pat_index = return_value.find(end_pattern)
+            match = self.__find_match(return_value[:end_pat_index + len(end_pattern)])
 
-            return return_value
-        else:
-            return string
+        return return_value
 
     def get_list_direct(self, string):
         """


### PR DESCRIPTION
Change the function to expand variable to use a simplified logic
Make sure it only perform an expand/replace when there is a match

Test is added in internal repo