### PR TITLE
WAR-1575: As a user, I need a support to send emails to multiple receivers

### DIFF
--- a/warrior/Framework/Utils/email_utils.py
+++ b/warrior/Framework/Utils/email_utils.py
@@ -163,6 +163,7 @@ def send_email(smtp_host, sender, receivers, subject, body, files):
     message = MIMEMultipart()
     message['From'] = sender
     message['To'] = receivers
+    receivers_list = [receiver.strip() for receiver in receivers.split(',')]
     message['Subject'] = subject
 
     part = MIMEText(body, 'plain')
@@ -179,7 +180,7 @@ def send_email(smtp_host, sender, receivers, subject, body, files):
 
     try:
         smtp_obj = smtplib.SMTP(smtp_host)
-        smtp_obj.sendmail(sender, receivers, message.as_string())
+        smtp_obj.sendmail(sender, receivers_list, message.as_string())
         pNote('Execution results emailed to receiver(s): {}'.format(receivers))
         smtp_obj.close()
 

--- a/warrior/Tools/w_settings.xml
+++ b/warrior/Tools/w_settings.xml
@@ -14,9 +14,9 @@
             3. every_failure - to send an email whenever a case fails during suite/project execution
          When 'mail_on attribute' is not given or left empty, default value will be used for sending email.
          It also accepts comma separated values, example mail_on="per_execution, first_failure" -->
-        <smtp_host></smtp_host> <!-- Optional, use FNC smtp host smtp.fnc.fujitsu.com to notify test case execution results -->
-        <sender></sender> <!-- Optional, use sender's email such as Warrior_PBO@fnc.fujitsu.com -->
-        <receiver></receiver> <!-- Optional, use receiver's email such as FNC.User@fnc.fujitsu.com -->
+        <smtp_host></smtp_host> <!-- Name of the host running your SMTP server(IP address or DNS name) -->
+        <sender></sender> <!-- Sender email id -->
+        <receiver></receiver> <!-- Receiver(s) email id, use comma to separate multiple receivers -->
         <subject></subject> <!-- Optional, use this as subject line such as WARRIOR , additional test case execution results Pass/Fail and Test Execution File shall be appended to this -->
     </Setting>
 </Default>


### PR DESCRIPTION
Add a support to send warrior notification emails to multiple receivers - when comma separated value is given w_settings file.

Logs and test instructions in the jira ticket.