### PR TITLE
bugfix/WAR-1609-new: resolved commit-id not working in label tag

### DIFF
--- a/warhorn/source/utils.py
+++ b/warhorn/source/utils.py
@@ -777,12 +777,11 @@ def git_checkout_label(label, base_path="", current_dir=""):
     try:
         # checking out label
         subprocess.check_call(["git", "checkout", label])
-        # getting current label in current_label
-        current_label = subprocess.check_output(["git", "symbolic-ref",
-                                                 '--short', 'HEAD']).strip()
+        # getting current commit id (%H) and label (%d)
+        current_label = subprocess.check_output(["git", "show", '--format="%H%d"', "--no-patch"])
     except:
         check = False
-    if current_label != label:
+    if label not in current_label:
         check = False
     if current_dir != "":
         os.chdir(current_dir)

--- a/warhorn/warhorn.py
+++ b/warhorn/warhorn.py
@@ -229,10 +229,10 @@ def print_out_checkout_status(label, check, current_tag, repo_name, **kwargs):
     """Git checkout status reporting"""
     logfile = kwargs.get("logfile")
     print_log_name = kwargs.get("print_log_name")
-    if check and current_tag == label:
+    if check and label in current_tag:
         print_info("Checkout complete. " + repo_name + " version: " + label,
                    logfile, print_log_name)
-    elif not check and current_tag != label:
+    elif not check and label not in current_tag:
         print_error(label + " seems to be an invalid tag name\n" + repo_name +
                     " is now running: " + current_tag,
                     logfile, print_log_name)


### PR DESCRIPTION
giving commit id in label tag for warhorn configuration was not working like giving proper branch name. Check giving commit id and warhorn pulls the right files. 