### PR TITLE
WAR-1548 Refactor selenium keyword to support both selenium 2.0 and 3.0 with different version of chrome/firefox

### DIFF
--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -215,14 +215,21 @@ class browser_actions(object):
                 browser_details = selenium_Utils.\
                     get_browser_details(browser, datafile=self.datafile, **arguments)
             if browser_details is not None:
-                if type == "firefox":
-                    ff_profile = self.browser_object.\
-                        set_firefoxprofile(proxy_ip, proxy_port)
-                if binary != "" and gecko_path != "":
+                if browser_details["type"] == "firefox":
+                    # If browser type is firefox, needs to have geckodriver path
+                    # if firefox version >= 47 and selenium must be >= 3.5 in order to support geckodriver
+                    if gecko_path is None:
+                        gecko_path = browser_details.get("gecko_path", None)
+
+                    ff_profile = self.browser_object.set_firefoxprofile(proxy_ip, proxy_port)
                     browser_inst = self.browser_object.open_browser(
                         browser_details["type"], webdriver_remote_url,
                         binary=binary, gecko_path=gecko_path,
                         profile_dir=ff_profile)
+                elif browser_details["type"] != "firefox":
+                    # assuming it is chrome
+                    browser_inst = self.browser_object.open_browser(browser_details["type"],
+                                                                    webdriver_remote_url)
                 else:
                     pNote("Please provide valid path for binary/geckodriver")
                 if browser_inst:

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -232,6 +232,7 @@ class browser_actions(object):
                                                                     webdriver_remote_url)
                 else:
                     pNote("Please provide valid path for binary/geckodriver")
+
                 if browser_inst:
                     browser_fullname = "{0}_{1}".format(system_name,
                                                         browser_details["browser_name"])

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -488,15 +488,11 @@ class BrowserManagement(object):
                         profile_dir)
             else:
                 ff_capabilities = webdriver.DesiredCapabilities.FIREFOX
-                if ff_capabilities['marionette']:
-                    ff_capabilities['acceptInsecureCerts'] = True
-                    ffbinary = FirefoxBinary(binary)
-                    browser = webdriver.Firefox(firefox_binary=ffbinary,
-                                                firefox_profile=profile_dir,
-                                                executable_path=gecko_path)
-                else:
-                    print_info("Something is wrong in here, not launching firefox with gecko and binary")
-                    browser = webdriver.Firefox(firefox_profile=profile_dir)
+                ff_capabilities['acceptInsecureCerts'] = True
+                ffbinary = FirefoxBinary(binary)
+                browser = webdriver.Firefox(firefox_binary=ffbinary,
+                                            firefox_profile=profile_dir,
+                                            executable_path=gecko_path)
             return browser
         except WebDriverException as e:
             if "executable needs to be in PATH" in str(e):

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -490,6 +490,9 @@ class BrowserManagement(object):
                 ff_capabilities = webdriver.DesiredCapabilities.FIREFOX
                 ff_capabilities['acceptInsecureCerts'] = True
                 ffbinary = FirefoxBinary(binary)
+                print ffbinary
+                print profile_dir
+                print gecko_path
                 browser = webdriver.Firefox(firefox_binary=ffbinary,
                                             firefox_profile=profile_dir,
                                             executable_path=gecko_path)

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -87,7 +87,10 @@ class BrowserManagement(object):
 
         """
         browser_detail_dict = {}
-        browser_detail_dict['version'] = browser.capabilities['version']
+        browser_version = browser.capabilities.get("version", None)
+        if browser_version is None:
+            browser_version = browser.capabilities.get("browserVersion", None)
+        browser_detail_dict['version'] = browser_version
         return browser_detail_dict
 
     def close_browser(self, browser_instance=None):
@@ -272,7 +275,12 @@ class BrowserManagement(object):
         if browser_instance is None:
             browser_instance = self.current_browser
 
-        if browser_type == "firefox":
+        version = self.get_browser_details(browser_instance).get("version", "")
+        print version
+
+        from distutils.version import LooseVersion
+
+        if browser_type == "firefox" and LooseVersion(version) < LooseVersion("47.0.0"):
             element = browser_instance.find_element_by_tag_name("body")
             element.send_keys(Keys.LEFT_CONTROL, 'n')
         else:
@@ -487,6 +495,7 @@ class BrowserManagement(object):
                                                 firefox_profile=profile_dir,
                                                 executable_path=gecko_path)
                 else:
+                    print_info("Something is wrong in here, not launching firefox with gecko and binary")
                     browser = webdriver.Firefox(firefox_profile=profile_dir)
             return browser
         except WebDriverException as e:
@@ -494,6 +503,8 @@ class BrowserManagement(object):
                 print_error("Please provide path for geckodriver executable")
             elif "Expected browser binary location" in str(e):
                 print_error("Please provide path of firefox executable")
+        except Exception as e:
+            print_error("Encountered Error {0}, while creating Firefox instance".format(e))
 
     def _make_chrome(self, webdriver_remote_url, desired_capabilities,
                      profile_dir, binary, gecko_path):

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -490,11 +490,8 @@ class BrowserManagement(object):
                 ff_capabilities = webdriver.DesiredCapabilities.FIREFOX
                 ff_capabilities['acceptInsecureCerts'] = True
                 # ffbinary = FirefoxBinary(binary)
-                # print ffbinary
-                print profile_dir
-                print gecko_path
-                browser = webdriver.Firefox(firefox_profile=profile_dir,
-                                            executable_path=gecko_path)
+                browser = webdriver.Firefox(executable_path=gecko_path)
+                print "browser", browser
             return browser
         except WebDriverException as e:
             if "executable needs to be in PATH" in str(e):

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -489,12 +489,11 @@ class BrowserManagement(object):
             else:
                 ff_capabilities = webdriver.DesiredCapabilities.FIREFOX
                 ff_capabilities['acceptInsecureCerts'] = True
-                ffbinary = FirefoxBinary(binary)
-                print ffbinary
+                # ffbinary = FirefoxBinary(binary)
+                # print ffbinary
                 print profile_dir
                 print gecko_path
-                browser = webdriver.Firefox(firefox_binary=ffbinary,
-                                            firefox_profile=profile_dir,
+                browser = webdriver.Firefox(firefox_profile=profile_dir,
                                             executable_path=gecko_path)
             return browser
         except WebDriverException as e:


### PR DESCRIPTION
This ticket also includes changes for WAR-1591
and necessary support for WAR-1074 to run correctly

With firefox version 47 and above, a geckodriver is needed in the local sys env path
https://github.com/mozilla/geckodriver/releases
Chrome needs chromedriver
https://sites.google.com/a/chromium.org/chromedriver/downloads

if geckodriver is needed, then selenium version needs to be 3.5 or above
https://github.com/mozilla/geckodriver#selenium
which means for Firefox 47 and above, warrior needs both geckodriver and selenium >= 3.5 to run
Chrome isn't affected

For geckodriver launched firefox
currently found that browser.capabilities dict has "browserVersion" instead of "version"
needs to handle this kind of key changes in warriorframework

Code is not ready to review, hence no reviewers have been added
PR is opened solely for compare purpose