### PR TITLE
WAR-1548 Refactor selenium keyword to support both selenium 2.0 and 3.0 with different version of chrome/firefox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,18 +37,18 @@ matrix:
 
 before_install:
     - if [ ${INSTALL} = "yes" ]; then
-        # sudo apt-get install xvfb ;
+        sudo apt-get install xvfb ;
       fi
 
 install:
     - if [ ${INSTALL} = "yes" ]; then
-        # pip install pexpect==4.2 ;
-        # pip install requests==2.9.1 ;
-        # pip install selenium==2.53.0 ;
-        # pip install lxml==3.3.3 ;
-        # pip install paramiko==1.16.0 ;
-        # pip install pysnmp==4.3.2 ;
-        # pip install pyvirtualdisplay==0.2.1 ;
+        pip install pexpect==4.2 ;
+        pip install requests==2.9.1 ;
+        pip install selenium==2.53.0 ;
+        pip install lxml==3.3.3 ;
+        pip install paramiko==1.16.0 ;
+        pip install pysnmp==4.3.2 ;
+        pip install pyvirtualdisplay==0.2.1 ;
         wget https://chromedriver.storage.googleapis.com/2.34/chromedriver_linux64.zip
         unzip chromedriver_linux64.zip
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,11 @@ matrix:
       python: 2.7
       addons:
         firefox: "46.0"
+    - os: linux
+      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/testcases/selenium_tests/tc_selenium_headless.xml SELENIUM=yes SELENIUM3=yes
+      python: 2.7
+      addons:
+        firefox: "46.0"
 
 install:
     - if [ ${INSTALL} = "yes" ]; then
@@ -51,6 +56,9 @@ install:
         unzip chromedriver_linux64.zip;
         chmod +x chromedriver;
         sudo mv chromedriver /usr/local/bin/;
+      fi
+    - if [ ${SELENIUM3} = "yes" ]; then
+        pip install selenium==3.8
       fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,8 @@ install:
         pip install pyvirtualdisplay==0.2.1 ;
         wget https://chromedriver.storage.googleapis.com/2.34/chromedriver_linux64.zip;
         unzip chromedriver_linux64.zip;
-        mv -f chromedriver /usr/local/share/;
-        chmod +x /usr/local/share/chromedriver;
-        ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver;
+        chmod +x chromedriver;
+        sudo ln -s chromedriver /usr/local/bin/chromedriver;
       fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,43 +2,38 @@ language: python
 
 matrix:
   include:
-    # - os: linux
-    #   env: INSTALL=no TESTFILE=./wftests/warrior_tests/projects/pj_common_actions.xml
-    #   python: 2.7
-    # - os: linux
-    #   env: INSTALL=yes TESTFILE=./wftests/ci/pylint.sh PYLINT=yes
-    #   python: 2.7
-    # - os: linux
-    #   env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_runmode_retry_at_suite_level_at_project_file.xml
-    #   python: 2.7
-    # - os: linux
-    #   env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_iterative_execution.xml
-    #   python: 2.7
-    # - os: linux
-    #   env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_parallel_execution.xml
-    #   python: 2.7
-    # - os: linux
-    #   env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_cond_var.xml
-    #   python: 2.7
-    # - os: linux
-    #   env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_rest.xml
-    #   python: 2.7
-    # - os: linux
-    #   env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_retry.xml
-    #   python: 2.7
-    # - os: linux
-    #   env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_parallel_execution_2.xml
-    #   python: 2.7
     - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/testcases/selenium_tests/tc_selenium_headless.xml
+      env: INSTALL=no TESTFILE=./wftests/warrior_tests/projects/pj_common_actions.xml
+      python: 2.7
+    - os: linux
+      env: INSTALL=yes TESTFILE=./wftests/ci/pylint.sh PYLINT=yes
+      python: 2.7
+    - os: linux
+      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_runmode_retry_at_suite_level_at_project_file.xml
+      python: 2.7
+    - os: linux
+      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_iterative_execution.xml
+      python: 2.7
+    - os: linux
+      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_parallel_execution.xml
+      python: 2.7
+    - os: linux
+      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_cond_var.xml
+      python: 2.7
+    - os: linux
+      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_rest.xml
+      python: 2.7
+    - os: linux
+      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_retry.xml
+      python: 2.7
+    - os: linux
+      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_parallel_execution_2.xml
+      python: 2.7
+    - os: linux
+      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/testcases/selenium_tests/tc_selenium_headless.xml SELENIUM=yes
       python: 2.7
       addons:
         firefox: "46.0"
-
-before_install:
-    - if [ ${INSTALL} = "yes" ]; then
-        sudo apt-get install xvfb ;
-      fi
 
 install:
     - if [ ${INSTALL} = "yes" ]; then
@@ -48,7 +43,10 @@ install:
         pip install lxml==3.3.3 ;
         pip install paramiko==1.16.0 ;
         pip install pysnmp==4.3.2 ;
+      fi
+    - if [ ${SELENIUM} = "yes" ]; then
         pip install pyvirtualdisplay==0.2.1 ;
+        sudo apt-get install xvfb ;
         wget https://chromedriver.storage.googleapis.com/2.34/chromedriver_linux64.zip;
         unzip chromedriver_linux64.zip;
         chmod +x chromedriver;

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,33 +2,38 @@ language: python
 
 matrix:
   include:
+    # - os: linux
+    #   env: INSTALL=no TESTFILE=./wftests/warrior_tests/projects/pj_common_actions.xml
+    #   python: 2.7
+    # - os: linux
+    #   env: INSTALL=yes TESTFILE=./wftests/ci/pylint.sh PYLINT=yes
+    #   python: 2.7
+    # - os: linux
+    #   env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_runmode_retry_at_suite_level_at_project_file.xml
+    #   python: 2.7
+    # - os: linux
+    #   env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_iterative_execution.xml
+    #   python: 2.7
+    # - os: linux
+    #   env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_parallel_execution.xml
+    #   python: 2.7
+    # - os: linux
+    #   env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_cond_var.xml
+    #   python: 2.7
+    # - os: linux
+    #   env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_rest.xml
+    #   python: 2.7
+    # - os: linux
+    #   env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_retry.xml
+    #   python: 2.7
+    # - os: linux
+    #   env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_parallel_execution_2.xml
+    #   python: 2.7
     - os: linux
-      env: INSTALL=no TESTFILE=./wftests/warrior_tests/projects/pj_common_actions.xml
+      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/testcases/pj_parallel_execution_2.xml
       python: 2.7
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/ci/pylint.sh PYLINT=yes
-      python: 2.7
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_cond_var.xml
-      python: 2.7
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_rest.xml
-      python: 2.7
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_retry.xml
-      python: 2.7
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_iterative_execution.xml
-      python: 2.7
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_parallel_execution.xml
-      python: 2.7
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_parallel_execution_2.xml
-      python: 2.7
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_runmode_retry_at_suite_level_at_project_file.xml
-      python: 2.7
+      addons:
+        firefox: "46.0"
 
 before_install:
     - if [ ${INSTALL} = "yes" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
     #   env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_parallel_execution_2.xml
     #   python: 2.7
     - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/testcases/pj_parallel_execution_2.xml
+      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/testcases/selenium_tests/tc_selenium_headless.xml
       python: 2.7
       addons:
         firefox: "46.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,9 @@ install:
         pip install pyvirtualdisplay==0.2.1 ;
         wget https://chromedriver.storage.googleapis.com/2.34/chromedriver_linux64.zip;
         unzip chromedriver_linux64.zip;
+        mv -f chromedriver /usr/local/share/;
+        chmod +x /usr/local/share/chromedriver;
+        ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver;
       fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,8 @@ install:
         pip install paramiko==1.16.0 ;
         pip install pysnmp==4.3.2 ;
         pip install pyvirtualdisplay==0.2.1 ;
-        wget https://chromedriver.storage.googleapis.com/2.34/chromedriver_linux64.zip
-        unzip chromedriver_linux64.zip
+        wget https://chromedriver.storage.googleapis.com/2.34/chromedriver_linux64.zip;
+        unzip chromedriver_linux64.zip;
       fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,18 +37,20 @@ matrix:
 
 before_install:
     - if [ ${INSTALL} = "yes" ]; then
-        sudo apt-get install xvfb ;
+        # sudo apt-get install xvfb ;
       fi
 
 install:
     - if [ ${INSTALL} = "yes" ]; then
-        pip install pexpect==4.2 ;
-        pip install requests==2.9.1 ;
-        pip install selenium==2.53.0 ;
-        pip install lxml==3.3.3 ;
-        pip install paramiko==1.16.0 ;
-        pip install pysnmp==4.3.2 ;
-        pip install pyvirtualdisplay==0.2.1 ;
+        # pip install pexpect==4.2 ;
+        # pip install requests==2.9.1 ;
+        # pip install selenium==2.53.0 ;
+        # pip install lxml==3.3.3 ;
+        # pip install paramiko==1.16.0 ;
+        # pip install pysnmp==4.3.2 ;
+        # pip install pyvirtualdisplay==0.2.1 ;
+        wget https://chromedriver.storage.googleapis.com/2.34/chromedriver_linux64.zip
+        unzip chromedriver_linux64.zip
       fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
         wget https://chromedriver.storage.googleapis.com/2.34/chromedriver_linux64.zip;
         unzip chromedriver_linux64.zip;
         chmod +x chromedriver;
-        sudo ln -s chromedriver /usr/local/bin/chromedriver;
+        sudo mv chromedriver /usr/local/bin/;
       fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install:
         sudo mv chromedriver /usr/local/bin/;
       fi
     - if [ ${SELENIUM3} = "yes" ]; then
-        pip install selenium==3.8
+        pip install selenium==3.8 ;
       fi
 
 script:

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -218,6 +218,7 @@ class browser_actions(object):
 
         if str(optional_args["headless_mode"]).strip().lower() in ["yes", "y"]:
             status = selenium_Utils.create_display()
+            browser_object.headless_mode = True
             if not status:
                 browser_list = []
 

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -133,7 +133,7 @@ class browser_actions(object):
                              FOR TEST CASE
                              Eg: <argument name="element_tag" value="json_name_1">
 
-            The following 4 arguments are added for Selenium 3 with Firefox
+            The next 5 arguments are added for Selenium 3 with Firefox
             9. binary = The absolute path of the browser executable
                         Eg: <binary>../../firefox/firefox</binary>
 
@@ -144,14 +144,18 @@ class browser_actions(object):
                              https://github.com/mozilla/geckodriver#selenium
                              Eg: <gecko_path>../../../geckodriver</gecko_path>
 
-            11. proxy_ip = This <proxy_ip> tag refers to the ip of the proxy
+            11. gecko_log
+
+            12. proxy_ip = This <proxy_ip> tag refers to the ip of the proxy
                            server. When a proxy is required this tag has to set
                            Eg: <proxy_ip>xx.xxx.xx.xx</proxy_ip>
 
-            12. proxy_port = This <proxy_port> tag refers to the port of the
+            13. proxy_port = This <proxy_port> tag refers to the port of the
                             proxy server. When a proxy is required for
                             remote connection this tag has to set.
                            Eg: <proxy_port>yyyy</proxy_port>
+
+            14. headless_mode
 
         :Arguments:
 
@@ -171,6 +175,7 @@ class browser_actions(object):
             10. gecko_path(str) = Absolute path of the geckodriver
             11. proxy_ip(str) = IP of the proxy server
             12. proxy_port(str) = port of the proxy server
+
 
         :Returns:
 
@@ -223,7 +228,7 @@ class browser_actions(object):
             if browser_details is not None:
                 # Call utils to launch correct type of browser
                 # Need to pass the binary, gecko_path, proxy_ip, proxy_port if specified
-                browser_optional_arg_keys = ["binary", "gecko_path", "proxy_ip", "proxy_port"]
+                browser_optional_arg_keys = ["binary", "gecko_path", "proxy_ip", "proxy_port", "gecko_log"]
                 browser_optional_args = {}
                 for arg in browser_optional_arg_keys:
                     if browser_details.get(arg) is not None:

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -193,6 +193,8 @@ class browser_actions(object):
         for arg in optional_arg_keys:
             if arguments.get(arg, None) is None:
                 optional_args[arg] = data_Utils.getSystemData(self.datafile, system_name, arg)
+                if optional_args[arg] is False:
+                    optional_args[arg] = None
 
         optional_args["webdriver_remote_url"] = optional_args["ip"]\
             if str(optional_args["remote"]).strip().lower() == "yes" else False

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -221,6 +221,8 @@ class browser_actions(object):
             output_dict[system_name+"_headless"] = True
             if not status:
                 browser_list = []
+        else:
+            output_dict[system_name+"_headless"] = False
 
         for browser in browser_list:
             arguments = Utils.data_Utils.get_default_ecf_and_et(arguments, self.datafile, browser)

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -333,7 +333,7 @@ class browser_actions(object):
             if browser_details is not None:
                 current_browser = Utils.data_Utils.get_object_from_datarepository(system_name + "_" + browser_details["browser_name"])
                 if current_browser:
-                    self.browser_object.maximize_browser_window(current_browser)
+                    status = self.browser_object.maximize_browser_window(current_browser)
                 else:
                     pNote("Browser of system {0} and name {1} not found in the"
                           "datarepository"

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -1576,15 +1576,19 @@ class browser_actions(object):
                     get_object_from_datarepository(system_name + "_" +
                                                    browser_details["browser_name"])
                 if current_browser:
-                    self.browser_object.open_tab(current_browser,
-                                                 browser_details["url"],
-                                                 browser_details["type"])
+                    try:
+                        status = self.browser_object.open_tab(current_browser,
+                                                              browser_details["url"],
+                                                              browser_details["type"])\
+                                 if status != "Error" else status
+                    except Exception:
+                        status = "Error"
                 else:
                     pNote("Browser of system {0} and name {1} not found in the "
                           "datarepository"
                           .format(system_name, browser_details["browser_name"]),
                           "Exception")
-                    status = False
+                    status = False if status != "Error" else status
             browser_details = {}
         Utils.testcase_Utils.report_substep_status(status)
         if current_browser:

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -51,8 +51,7 @@ class browser_actions(object):
 
     def browser_launch(self, system_name, browser_name="all", type="firefox",
                        url=None, ip=None, remote=None, element_config_file=None,
-                       element_tag=None, binary=None, gecko_path=None,
-                       proxy_ip=None, proxy_port=None):
+                       element_tag=None):
         """
         The Keyword would launch a browser and Navigate to the url, if provided by the user.
 
@@ -89,13 +88,13 @@ class browser_actions(object):
 
                         Eg: <remote>yes</remote>
 
-            4. type = This <type> tag is a child of the <browser> tag in the
+            4. type = This <type> tag is a child og the <browser> tag in the
                       data file. The type of browser that should be opened can
                       be added in here.
 
                       Eg: <type>firefox</type>
 
-            5. browser_name = This <browser_name> tag is a child of the
+            5. browser_name = This <browser_name> tag is a child og the
                               <browser> tag in the data file. Each browser
                               instance should have a unique name. This name can
                               be added here
@@ -132,23 +131,6 @@ class browser_actions(object):
                              FOR TEST CASE
                              Eg: <argument name="element_tag" value="json_name_1">
 
-            9. binary = This <binary> tag refers to path of the browser to
-                        invoke
-                        Eg: <binary>../../firefox/firefox</binary>
-
-            10. gecko_path = This <gecko_path> tag refers to path of the
-                             geckodriver
-                            Eg: <gecko_path>../../../geckodriver</gecko_path>
-
-            11. proxy_ip = This <proxy_ip> tag refers to the ip of the proxy
-                           server. When a proxy is required this tag has to set
-                           Eg: <proxy_ip>xx.xxx.xx.xx</proxy_ip>
-
-            12. proxy_port = This <proxy_port> tag refers to the port of the
-                            proxy server. When a proxy is required for
-                            remote connection this tag has to set.
-                           Eg: <proxy_port>yyyy</proxy_port>
-
         :Arguments:
 
             1. system_name(str) = the system name.
@@ -163,10 +145,6 @@ class browser_actions(object):
                                            locators
             8. element_tag (str) = particular element in the json fie which
                                    contains relevant information to that element
-            9. binary(str) = path of the browser
-            10. gecko_path(str) = path of the geckodriver
-            11. proxy_ip(str) = IP of the proxy server
-            12. proxy_port(str) = port of the proxy server
 
         :Returns:
 
@@ -208,23 +186,13 @@ class browser_actions(object):
             browser_details = arguments
 
         for browser in browser_list:
-            arguments = Utils.data_Utils.get_default_ecf_and_et(arguments,
-                                                                self.datafile,
-                                                                browser)
+            arguments = Utils.data_Utils.get_default_ecf_and_et(arguments, self.datafile, browser)
             if browser_details == {}:
                 browser_details = selenium_Utils.\
                     get_browser_details(browser, datafile=self.datafile, **arguments)
             if browser_details is not None:
-                if type == "firefox":
-                    ff_profile = self.browser_object.\
-                        set_firefoxprofile(proxy_ip, proxy_port)
-                if binary != "" and gecko_path != "":
-                    browser_inst = self.browser_object.open_browser(
-                        browser_details["type"], webdriver_remote_url,
-                        binary=binary, gecko_path=gecko_path,
-                        profile_dir=ff_profile)
-                else:
-                    pNote("Please provide valid path for binary/geckodriver")
+                browser_inst = self.browser_object.open_browser(
+                    browser_details["type"], webdriver_remote_url)
                 if browser_inst:
                     browser_fullname = "{0}_{1}".format(system_name,
                                                         browser_details["browser_name"])

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -188,13 +188,11 @@ class browser_actions(object):
         pSubStep(wdesc)
         browser_details = {}
 
-        optional_arg_keys = ["ip", "remote", "binary", "gecko_path", "proxy_ip", "proxy_port"]
+        optional_arg_keys = ["ip", "remote"]
         optional_args = {}
         for arg in optional_arg_keys:
             if arguments.get(arg, None) is None:
                 optional_args[arg] = data_Utils.getSystemData(self.datafile, system_name, arg)
-                if optional_args[arg] is False:
-                    optional_args[arg] = None
 
         optional_args["webdriver_remote_url"] = optional_args["ip"]\
             if str(optional_args["remote"]).strip().lower() == "yes" else False
@@ -220,8 +218,13 @@ class browser_actions(object):
             if browser_details is not None:
                 # Call utils to launch correct type of browser
                 # Need to pass the binary, gecko_path, proxy_ip, proxy_port if specified
+                browser_optional_arg_keys = ["binary", "gecko_path", "proxy_ip", "proxy_port"]
+                browser_optional_args = {}
+                for arg in browser_optional_arg_keys:
+                    if browser_details.get(arg) is not None:
+                        browser_optional_args[arg] = browser_details.get(arg)
                 browser_inst = self.browser_object.open_browser(
-                    browser_details["type"], **optional_args)
+                    browser_details["type"], **browser_optional_args)
                 if browser_inst:
                     browser_fullname = "{0}_{1}".format(system_name,
                                                         browser_details["browser_name"])

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -215,6 +215,7 @@ class browser_actions(object):
                               get_browser_details(browser, datafile=self.datafile, **arguments)
             if browser_details is not None:
                 # Call utils to launch correct type of browser
+                # Need to pass the binary, gecko_path, proxy_ip, proxy_port if specified
                 browser_inst = self.browser_object.open_browser(
                     browser_details["type"], webdriver_remote_url)
                 if browser_inst:

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -10,26 +10,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-from Framework.Utils.rest_Utils import remove_invalid_req_args
 
 """ Selenium keywords for Generic Browser Actions """
 
-import os, re
+import os
 from urlparse import urlparse
 from Framework.ClassUtils.WSelenium.browser_mgmt import BrowserManagement
 from Actions.SeleniumActions.verify_actions import verify_actions
 from Actions.SeleniumActions.elementlocator_actions import elementlocator_actions
 
-try:
-    import Framework.Utils as Utils
-except ImportWarning:
-    raise ImportError
-
+import Framework.Utils as Utils
 from Framework.Utils import selenium_Utils
 from Framework.Utils import data_Utils
 from Framework.Utils import xml_Utils
 from Framework.Utils.testcase_Utils import pNote, pSubStep
 from Framework.ClassUtils.json_utils_class import JsonUtils
+from Framework.Utils.rest_Utils import remove_invalid_req_args
 
 
 class browser_actions(object):
@@ -338,8 +334,10 @@ class browser_actions(object):
                 browser_details = selenium_Utils. \
                     get_browser_details(browser, datafile=self.datafile, **arguments)
             if browser_details is not None:
-                current_browser = Utils.data_Utils.get_object_from_datarepository(system_name + "_" + browser_details["browser_name"])
-                headless = Utils.data_Utils.get_object_from_datarepository(system_name + "_headless")
+                current_browser = Utils.data_Utils.get_object_from_datarepository(
+                    system_name + "_" + browser_details["browser_name"])
+                headless = Utils.data_Utils.get_object_from_datarepository(
+                    system_name + "_headless")
                 if current_browser:
                     status &= self.browser_object.maximize_browser_window(current_browser, headless)
                 else:
@@ -1581,8 +1579,8 @@ class browser_actions(object):
                                                    browser_details["browser_name"])
                 if current_browser:
                         status &= self.browser_object.open_tab(current_browser,
-                                                              browser_details["url"],
-                                                              browser_details["type"])
+                                                               browser_details["url"],
+                                                               browser_details["type"])
                 else:
                     pNote("Browser of system {0} and name {1} not found in the "
                           "datarepository"
@@ -2517,7 +2515,8 @@ class browser_actions(object):
                     get_object_from_datarepository(system_name + "_" +
                                                    browser_details["browser_name"])
                 if current_browser:
-                    status = self.browser_object.delete_a_specific_cookie(current_browser, browser_details["cookie_name"])
+                    status = self.browser_object.delete_a_specific_cookie(
+                        current_browser, browser_details["cookie_name"])
                 else:
                     pNote("Browser of system {0} and name {1} not found in the "
                           "datarepository"

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -188,12 +188,14 @@ class browser_actions(object):
         pSubStep(wdesc)
         browser_details = {}
 
-        if ip is None:
-            ip = data_Utils.getSystemData(self.datafile, system_name, "ip")
-        if remote is None:
-            remote = data_Utils.getSystemData(self.datafile, system_name, "remote")
+        optional_arg_keys = ["ip", "remote", "binary", "gecko_path", "proxy_ip", "proxy_port"]
+        optional_args = {}
+        for arg in optional_arg_keys:
+            if arguments.get(arg, None) is None:
+                optional_args[arg] = data_Utils.getSystemData(self.datafile, system_name, arg)
 
-        webdriver_remote_url = ip if str(remote).strip().lower() == "yes" else False
+        optional_args["webdriver_remote_url"] = optional_args["ip"]\
+            if str(optional_args["remote"]).strip().lower() == "yes" else False
 
         system = xml_Utils.getElementWithTagAttribValueMatch(self.datafile,
                                                              "system", "name", system_name)
@@ -217,7 +219,7 @@ class browser_actions(object):
                 # Call utils to launch correct type of browser
                 # Need to pass the binary, gecko_path, proxy_ip, proxy_port if specified
                 browser_inst = self.browser_object.open_browser(
-                    browser_details["type"], webdriver_remote_url)
+                    browser_details["type"], **optional_args)
                 if browser_inst:
                     browser_fullname = "{0}_{1}".format(system_name,
                                                         browser_details["browser_name"])

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -1581,7 +1581,8 @@ class browser_actions(object):
                                                               browser_details["url"],
                                                               browser_details["type"])\
                                  if status != "Error" else status
-                    except Exception:
+                    except RuntimeError as err:
+                        pNote(err, "Error")
                         status = "Error"
                 else:
                     pNote("Browser of system {0} and name {1} not found in the "

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -1576,20 +1576,15 @@ class browser_actions(object):
                     get_object_from_datarepository(system_name + "_" +
                                                    browser_details["browser_name"])
                 if current_browser:
-                    try:
-                        status = self.browser_object.open_tab(current_browser,
+                        status &= self.browser_object.open_tab(current_browser,
                                                               browser_details["url"],
-                                                              browser_details["type"])\
-                                 if status != "Error" else status
-                    except RuntimeError as err:
-                        pNote(err, "Error")
-                        status = "Error"
+                                                              browser_details["type"])
                 else:
                     pNote("Browser of system {0} and name {1} not found in the "
                           "datarepository"
                           .format(system_name, browser_details["browser_name"]),
                           "Exception")
-                    status = False if status != "Error" else status
+                    status &= False
             browser_details = {}
         Utils.testcase_Utils.report_substep_status(status)
         if current_browser:

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -234,7 +234,8 @@ class browser_actions(object):
             if browser_details is not None:
                 # Call utils to launch correct type of browser
                 # Need to pass the binary, gecko_path, proxy_ip, proxy_port if specified
-                browser_optional_arg_keys = ["binary", "gecko_path", "proxy_ip", "proxy_port", "gecko_log"]
+                browser_optional_arg_keys = ["binary", "gecko_path",
+                                             "proxy_ip", "proxy_port", "gecko_log"]
                 browser_optional_args = {}
                 for arg in browser_optional_arg_keys:
                     if browser_details.get(arg) is not None:

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -337,13 +337,13 @@ class browser_actions(object):
                 current_browser = Utils.data_Utils.get_object_from_datarepository(system_name + "_" + browser_details["browser_name"])
                 headless = Utils.data_Utils.get_object_from_datarepository(system_name + "_headless")
                 if current_browser:
-                    status = self.browser_object.maximize_browser_window(current_browser, headless)
+                    status &= self.browser_object.maximize_browser_window(current_browser, headless)
                 else:
                     pNote("Browser of system {0} and name {1} not found in the"
                           "datarepository"
                           .format(system_name, browser_details["browser_name"]),
                           "Exception")
-                    status = False
+                    status &= False
             browser_details = {}
         Utils.testcase_Utils.report_substep_status(status)
         return status

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -129,29 +129,35 @@ class browser_actions(object):
                              FOR TEST CASE
                              Eg: <argument name="element_tag" value="json_name_1">
 
+            9. headless_mode = Run selenium test in headless mode
+                                Used in system with no GUI component
+
             The next 5 arguments are added for Selenium 3 with Firefox
-            9. binary = The absolute path of the browser executable
+            Please use them inside the browser tag in system data file
+            binary = The absolute path of the browser executable
                         Eg: <binary>../../firefox/firefox</binary>
 
-            10. gecko_path = The absolute path of the geckodriver
-                             This is a mandatory argument if using Firefox version 47 or above
+            gecko_path = The absolute path of the geckodriver
+                             geckodriver is mandatory if using Firefox version 47 or above
                              This also required Selenium 3.5 or above
                              For more information please visit:
                              https://github.com/mozilla/geckodriver#selenium
                              Eg: <gecko_path>../../../geckodriver</gecko_path>
 
-            11. gecko_log
+            gecko_log = The absolute path for the geckodriver log to be saved
+                            This file only get generated if firefox is launched with geckodriver
+                            and failuer/error occur
+                            Default is the testcase log directory
 
-            12. proxy_ip = This <proxy_ip> tag refers to the ip of the proxy
+            proxy_ip = This <proxy_ip> tag refers to the ip of the proxy
                            server. When a proxy is required this tag has to set
                            Eg: <proxy_ip>xx.xxx.xx.xx</proxy_ip>
 
-            13. proxy_port = This <proxy_port> tag refers to the port of the
+            proxy_port = This <proxy_port> tag refers to the port of the
                             proxy server. When a proxy is required for
                             remote connection this tag has to set.
                            Eg: <proxy_port>yyyy</proxy_port>
 
-            14. headless_mode
 
         :Arguments:
 
@@ -167,10 +173,7 @@ class browser_actions(object):
                                            locators
             8. element_tag (str) = particular element in the json fie which
                                    contains relevant information to that element
-            9. binary(str) = Absolute path of the browser
-            10. gecko_path(str) = Absolute path of the geckodriver
-            11. proxy_ip(str) = IP of the proxy server
-            12. proxy_port(str) = port of the proxy server
+            9. headless_mode(str) = Enable headless_mode
 
 
         :Returns:
@@ -189,6 +192,7 @@ class browser_actions(object):
         pSubStep(wdesc)
         browser_details = {}
 
+        # Get optional argument from system data file if it is not specified in keyword arg
         optional_arg_keys = ["ip", "remote", "headless_mode"]
         optional_args = {}
         for arg in optional_arg_keys:
@@ -203,6 +207,7 @@ class browser_actions(object):
 
         browser_list = []
 
+        # Create a list of browser
         if system.findall("browser") is not None:
             browser_list.extend(system.findall("browser"))
         if system.find("browsers") is not None:
@@ -212,6 +217,7 @@ class browser_actions(object):
             "No browser found in system: {}, please check datafile".format(system_name)
             status = False
 
+        # Headless mode operation
         enable_headless = Utils.data_Utils.get_object_from_datarepository("wt_enable_headless")
         if str(optional_args["headless_mode"]).strip().lower() in ["yes", "y"] or enable_headless:
             status = selenium_Utils.create_display()

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -188,7 +188,7 @@ class browser_actions(object):
         pSubStep(wdesc)
         browser_details = {}
 
-        optional_arg_keys = ["ip", "remote"]
+        optional_arg_keys = ["ip", "remote", "headless_mode"]
         optional_args = {}
         for arg in optional_arg_keys:
             if arguments.get(arg, None) is None:
@@ -210,6 +210,11 @@ class browser_actions(object):
         if not browser_list:
             "No browser found in system: {}, please check datafile".format(system_name)
             status = False
+
+        if str(optional_args["headless_mode"]).strip().lower() in ["yes", "y"]:
+            status = selenium_Utils.create_display()
+            if not status:
+                browser_list = []
 
         for browser in browser_list:
             arguments = Utils.data_Utils.get_default_ecf_and_et(arguments, self.datafile, browser)

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -48,7 +48,7 @@ class browser_actions(object):
 
     def browser_launch(self, system_name, browser_name="all", type="firefox",
                        url=None, ip=None, remote=None, element_config_file=None,
-                       element_tag=None):
+                       element_tag=None, headless_mode=None):
         """
         The Keyword would launch a browser and Navigate to the url, if provided by the user.
 

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -218,7 +218,7 @@ class browser_actions(object):
 
         if str(optional_args["headless_mode"]).strip().lower() in ["yes", "y"]:
             status = selenium_Utils.create_display()
-            browser_object.headless_mode = True
+            output_dict[system_name+"_headless"] = True
             if not status:
                 browser_list = []
 
@@ -333,8 +333,9 @@ class browser_actions(object):
                     get_browser_details(browser, datafile=self.datafile, **arguments)
             if browser_details is not None:
                 current_browser = Utils.data_Utils.get_object_from_datarepository(system_name + "_" + browser_details["browser_name"])
+                headless = Utils.data_Utils.get_object_from_datarepository(system_name + "_headless")
                 if current_browser:
-                    status = self.browser_object.maximize_browser_window(current_browser)
+                    status = self.browser_object.maximize_browser_window(current_browser, headless)
                 else:
                     pNote("Browser of system {0} and name {1} not found in the"
                           "datarepository"

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -48,8 +48,7 @@ class browser_actions(object):
 
     def browser_launch(self, system_name, browser_name="all", type="firefox",
                        url=None, ip=None, remote=None, element_config_file=None,
-                       element_tag=None, binary=None, gecko_path=None,
-                       proxy_ip=None, proxy_port=None):
+                       element_tag=None):
         """
         The Keyword would launch a browser and Navigate to the url, if provided by the user.
 

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -216,11 +216,14 @@ class browser_actions(object):
             "No browser found in system: {}, please check datafile".format(system_name)
             status = False
 
-        if str(optional_args["headless_mode"]).strip().lower() in ["yes", "y"]:
+        enable_headless = Utils.data_Utils.get_object_from_datarepository("wt_enable_headless")
+        if str(optional_args["headless_mode"]).strip().lower() in ["yes", "y"] or enable_headless:
             status = selenium_Utils.create_display()
-            output_dict[system_name+"_headless"] = True
             if not status:
                 browser_list = []
+            else:
+                output_dict[system_name+"_headless"] = True
+                output_dict["headless_display"] = True
         else:
             output_dict[system_name+"_headless"] = False
 

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -34,11 +34,6 @@ try:
 except Exception as exception:
     print_exception(exception)
 
-
-BROWSER_NAMES = {'ff': "_make_ff",
-                 'firefox': "_make_ff",
-                 'chrome': "_make_chrome"
-                }
 class BrowserManagement(object):
     """Browser management class"""
 
@@ -411,16 +406,18 @@ class BrowserManagement(object):
         make browser methods to open a browser """
         creation_func = self._get_browser_creation_function(browser_name)
 
-        if not creation_func:
-            raise ValueError(browser_name + " is not a supported browser.")
+        if creation_func is None:
+            raise ValueError("{} is not a supported browser. Please use firefox or chrome".\
+                             format(browser_name))
 
         browser = creation_func(webdriver_remote_url, desired_capabilities, profile_dir)
         return browser
 
     def _get_browser_creation_function(self, browser_name):
         """Gets the browser function for the supported browsers
-        from the BROWSER_NAMES dictionary """
-        func_name = BROWSER_NAMES.get(browser_name.lower().replace(' ', ''))
+        from the browser_methods dictionary """
+        browser_methods = {'ff': "_make_ff", 'firefox': "_make_ff", 'chrome': "_make_chrome"}
+        func_name = browser_methods.get(browser_name.lower().replace(' ', ''))
         return getattr(self, func_name) if func_name else None
 
 

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -267,15 +267,15 @@ class BrowserManagement(object):
            LooseVersion(self.get_browser_version(browser_instance)) < LooseVersion("47.0.0"):
             element = browser_instance.find_element_by_tag_name("body")
             element.send_keys(Keys.LEFT_CONTROL, 'n')
-        elif browser_type == "firefox":
+        elif browser_type == "firefox" or (browser_type == "chrome" and\
+             LooseVersion(self.get_browser_version(browser_instance)) > LooseVersion("60.0.0")):
             # If FF version > 47, this action is not supported
-            print_error("Open tab operation is not supported in Firefox (47 or above)")
+            print_error("Firefox (47 or above) and Chrome with chromedriver (2.32 or above)"\
+                        "doesn't support opening new tab. Open tab may not function correctly")
             status = False
         else:
             element = browser_instance.find_element_by_tag_name("body")
             element.send_keys(Keys.LEFT_CONTROL, 't')
-        print_warning("Both Firefox (47 or above) and Chrome with chromedriver (2.32 or above)"\
-                      "doesn't support opening new tab. Open tab may not function correctly")
         sleep(1)
         browser_instance.switch_to.window(browser_instance.window_handles[len(browser_instance.window_handles) - 1])
 

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -527,6 +527,7 @@ class BrowserManagement(object):
                 else:
                     # gecko_log will only get generate if there is failure/error
                     # Need to specify log_path for geckodriver log
+                    # Gecko driver will only launch if FF version is 47 or above
                     optional_args["log_path"] = log_dir
 
                 ffbinary = FirefoxBinary(binary) if binary is not None else None

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -269,12 +269,13 @@ class BrowserManagement(object):
             element.send_keys(Keys.LEFT_CONTROL, 'n')
         elif browser_type == "firefox":
             # If FF version > 47, this action is not supported
-            print_error("Open tab operation is not supported in FF 47 or above")
+            print_error("Open tab operation is not supported in Firefox (47 or above)")
             status = False
         else:
-            # if chrome, open a new tab
             element = browser_instance.find_element_by_tag_name("body")
             element.send_keys(Keys.LEFT_CONTROL, 't')
+        print_warning("Both Firefox (47 or above) and Chrome with chromedriver (2.32 or above)"\
+                      "doesn't support opening new tab. Open tab may not function correctly")
         sleep(1)
         browser_instance.switch_to.window(browser_instance.window_handles[len(browser_instance.window_handles) - 1])
 

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -401,6 +401,16 @@ class BrowserManagement(object):
 
         return status
 
+    def get_browser_version(self, browser):
+        # Return the browser version as string
+        browser_version = browser.capabilities.get("version", None)
+        if browser_version is None:
+            browser_version = browser.capabilities.get("browserVersion", None)
+        if browser_version is None:
+            print_error("Unable to retrieve browser version, return False")
+            browser_version = False
+        return browser_version
+
     def set_firefox_proxy(self, profile_dir, proxy_ip, proxy_port):
         """method to update the given preferences in Firefox profile"""
         # Create a default Firefox profile first and update proxy_ip and port
@@ -460,14 +470,13 @@ class BrowserManagement(object):
                 ff_capabilities = webdriver.DesiredCapabilities.FIREFOX
                 # This is for internal testing needs...some https cert is not secure
                 ff_capabilities['acceptInsecureCerts'] = True
+                # Force disable marionette, works on Selenium 3 with FF ver < 47
+                # Without this line, selenium may encounter capability not found issue
                 ff_capabilities["marionette"] = False
                 ffbinary = FirefoxBinary(binary) if binary is not None else None
                 optional_args = {}
                 if gecko_path is not None:
                     optional_args["executable_path"] = gecko_path
-                print binary
-                print ffbinary
-                print optional_args
                 browser = webdriver.Firefox(firefox_binary=ffbinary,
                                             capabilities=ff_capabilities,
                                             firefox_profile=ff_profile, **optional_args)

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -48,7 +48,6 @@ class BrowserManagement(object):
         """Browser management constructor """
         self.current_browser = None
         self.current_window = None
-        self.headless_mode = False
 
     def open_browser(self, browser_name='firefox', webdriver_remote_url=False,
                      desired_capabilities=None, **kwargs):
@@ -95,14 +94,14 @@ class BrowserManagement(object):
             status = False
         return status
 
-    def maximize_browser_window(self, browser_instance=None):
+    def maximize_browser_window(self, browser_instance=None, headless_mode=False):
         """Maximizes current browser window."""
         status = True
         try:
             if browser_instance is not None:
                 # Need to distinguish whether browser is in headless mode or not
                 # as maximize_window doesn't work in headless mode
-                if self.headless_mode:
+                if headless_mode:
                     browser_instance.set_window_size(1920, 1080)
                 else:
                     browser_instance.maximize_window()

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -446,7 +446,7 @@ class BrowserManagement(object):
             if match is not None:
                 version = LooseVersion(match.group(0))
             else:
-                print raw_version
+                print_info("Cannot parse Firefox version: {}".format(raw_version))
         except CalledProcessError:
             print_error("Cannot find firefox version, will not launch browser")
         return version

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -275,6 +275,7 @@ class BrowserManagement(object):
                         "doesn't support opening new tab. Open tab may not function correctly")
             status = False
         else:
+            # If it is chrome ver < 60, actually open a new tab
             element = browser_instance.find_element_by_tag_name("body")
             element.send_keys(Keys.LEFT_CONTROL, 't')
         sleep(1)
@@ -517,6 +518,7 @@ class BrowserManagement(object):
         proxy_ip = kwargs.get("proxy_ip", None)
         proxy_port = kwargs.get("proxy_port", None)
         ff_profile = None
+        # if firefox is being used with proxy, set the profile here
         if proxy_ip is not None and proxy_port is not None:
             ff_profile = self.set_firefox_proxy(profile_dir, proxy_ip, proxy_port)
 
@@ -534,6 +536,7 @@ class BrowserManagement(object):
                 optional_args = {}
                 ff_capabilities = webdriver.DesiredCapabilities.FIREFOX
                 # This is for internal testing needs...some https cert is not secure
+                # And firefox will need to know how to handle it
                 ff_capabilities['acceptInsecureCerts'] = True
 
                 # Force disable marionette, only needs in Selenium 3 with FF ver < 47

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -48,6 +48,7 @@ class BrowserManagement(object):
         """Browser management constructor """
         self.current_browser = None
         self.current_window = None
+        self.headless_mode = False
 
     def open_browser(self, browser_name='firefox', webdriver_remote_url=False,
                      desired_capabilities=None, **kwargs):
@@ -101,8 +102,10 @@ class BrowserManagement(object):
             if browser_instance is not None:
                 # Need to distinguish whether browser is in headless mode or not
                 # as maximize_window doesn't work in headless mode
-                browser_instance.maximize_window()
-                browser_instance.set_window_size(1920, 1080)
+                if self.headless_mode:
+                    browser_instance.set_window_size(1920, 1080)
+                else:
+                    browser_instance.maximize_window()
 
             else:
                 self.current_browser.maximize_window()

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -448,7 +448,6 @@ class BrowserManagement(object):
         ff_profile = None
         if proxy_ip is not None and proxy_port is not None:
             ff_profile = self.set_firefox_proxy(profile_dir, proxy_ip, proxy_port)
-        # Need to check binary and gecko_path value
         # Need to check firefox version
 
         browser = None
@@ -459,12 +458,16 @@ class BrowserManagement(object):
                     webdriver_remote_url, desired_capabilites, ff_profile)
             else:
                 ff_capabilities = webdriver.DesiredCapabilities.FIREFOX
-                # This is for internal testing needs...
+                # This is for internal testing needs...some https cert is not secure
                 ff_capabilities['acceptInsecureCerts'] = True
+                ff_capabilities["marionette"] = False
                 ffbinary = FirefoxBinary(binary) if binary is not None else None
                 optional_args = {}
                 if gecko_path is not None:
                     optional_args["executable_path"] = gecko_path
+                print binary
+                print ffbinary
+                print optional_args
                 browser = webdriver.Firefox(firefox_binary=ffbinary,
                                             capabilities=ff_capabilities,
                                             firefox_profile=ff_profile, **optional_args)

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -268,7 +268,7 @@ class BrowserManagement(object):
             element.send_keys(Keys.LEFT_CONTROL, 'n')
         elif browser_type == "firefox":
             # If FF version > 47, this action is not supported
-            raise Exception
+            raise RuntimeError("Open tab operation is not supported in FF 47 or above")
         else:
             element = browser_instance.find_element_by_tag_name("body")
             element.send_keys(Keys.LEFT_CONTROL, 't')

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -99,7 +99,11 @@ class BrowserManagement(object):
         status = True
         try:
             if browser_instance is not None:
+                # Need to distinguish whether browser is in headless mode or not
+                # as maximize_window doesn't work in headless mode
                 browser_instance.maximize_window()
+                browser_instance.set_window_size(1920, 1080)
+
             else:
                 self.current_browser.maximize_window()
         except Exception as exception:
@@ -509,6 +513,7 @@ class BrowserManagement(object):
                 optional_args = {}
                 if gecko_path is not None:
                     optional_args["executable_path"] = gecko_path
+                # gecko_log will only get generate if there is failure/error
                 optional_args["log_path"] = log_dir
                 # Need to specify log_path for geckodriver log
                 browser = webdriver.Firefox(firefox_binary=ffbinary,

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -400,6 +400,21 @@ class BrowserManagement(object):
 
         return status
 
+    def set_firefox_proxy(self, profile_dir, proxy_ip, proxy_port):
+        """method to update the given preferences in Firefox profile"""
+        # Create a default Firefox profile first and update proxy_ip and port
+        ff_profile = webdriver.FirefoxProfile(profile_dir)
+        proxy_port = int(proxy_port)
+        ff_profile.set_preference("network.proxy.type", 1)
+        ff_profile.set_preference("network.proxy.http", proxy_ip)
+        ff_profile.set_preference("network.proxy.http_port", proxy_port)
+        ff_profile.set_preference("network.proxy.ssl", proxy_ip)
+        ff_profile.set_preference("network.proxy.ssl_port", proxy_port)
+        ff_profile.set_preference("network.proxy.ftp", proxy_ip)
+        ff_profile.set_preference("network.proxy.ftp_port", proxy_port)
+        ff_profile.update_preferences()
+
+        return ff_profile
 
     # private methods
     def _make_browser(self, browser_name, desired_capabilities=None,
@@ -427,6 +442,10 @@ class BrowserManagement(object):
         """Create an instance of firefox browser"""
         binary = kwargs.get("binary", None)
         gecko_path = kwargs.get("gecko_path", None)
+        proxy_ip = kwargs.get("proxy_ip", None)
+        proxy_port = kwargs.get("proxy_port", None)
+        if proxy_ip is not None and proxy_port is not None:
+            ff_profile = self.set_firefox_proxy(profile_dir, proxy_ip, proxy_port)
         # Need to check binary and gecko_path value
         # Need to check firefox version
 
@@ -435,7 +454,7 @@ class BrowserManagement(object):
             if webdriver_remote_url:
                 browser = self._create_remote_web_driver(
                     webdriver.DesiredCapabilities.FIREFOX,
-                    webdriver_remote_url, desired_capabilites, profile_dir)
+                    webdriver_remote_url, desired_capabilites, ff_profile)
             else:
                 ff_capabilities = webdriver.DesiredCapabilities.FIREFOX
                 # This is for internal testing needs...
@@ -443,7 +462,7 @@ class BrowserManagement(object):
                 ffbinary = FirefoxBinary(binary)
                 browser = webdriver.Firefox(firefox_binary=ffbinary,
                                             capabilities=ff_capabilities,
-                                            firefox_profile=profile_dir,
+                                            firefox_profile=ff_profile,
                                             executable_path=gecko_path)
         except WebDriverException as e:
             if "executable needs to be in PATH" in str(e):

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -66,29 +66,8 @@ class BrowserManagement(object):
         browser_name = browser_name
         browser = self._make_browser(browser_name, desired_capabilities,
                                      profile_dir, webdriver_remote_url,
-                                    binary=binary, gecko_path=gecko_path)
-        print_info("The Selenium Webdriver version is '{0}'".format(webdriver.__version__))
-        if browser:
-            browser_detail_dict = self.get_browser_details(browser)
-            for details, value in browser_detail_dict.items():
-                print_info("The Browser '{0}' {1} is '{2}'".format(browser_name, details, value))
+                                     binary=binary, gecko_path=gecko_path)
         return browser
-
-    def get_browser_details(self, browser):
-        """ Return the Browser details dict. The Dict can be updated with additional information
-        about the Browser
-
-            Arguments :
-                       browser = The browser instance
-
-            Return :
-                     browser_detail_dict = A Dictionary containing details of the browser instance
-                     such as version.
-
-        """
-        browser_detail_dict = {}
-        browser_detail_dict['version'] = browser.capabilities['version']
-        return browser_detail_dict
 
     def close_browser(self, browser_instance=None):
         """closes a browser session """

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -265,13 +265,13 @@ class BrowserManagement(object):
         if browser_type == "firefox" and\
            LooseVersion(self.get_browser_version(browser_instance)) < LooseVersion("47.0.0"):
             element = browser_instance.find_element_by_tag_name("body")
-            element.send_keys(Keys.LEFT_CONTROL, 'n')
+            element.send_keys(Keys.LEFT_CONTROL, 't')
         elif browser_type == "firefox":
             # If FF version > 47, this action is not supported
             raise RuntimeError("Open tab operation is not supported in FF 47 or above")
         else:
             element = browser_instance.find_element_by_tag_name("body")
-            element.send_keys(Keys.LEFT_CONTROL, 't')
+            element.send_keys(Keys.LEFT_CONTROL, 'n')
         sleep(1)
         browser_instance.switch_to.window(browser_instance.window_handles[len(browser_instance.window_handles) - 1])
 

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -35,10 +35,9 @@ try:
     from selenium.common.exceptions import WebDriverException
 
     KEYS = {1: Keys.NUMPAD1, 2: Keys.NUMPAD2, 3: Keys.NUMPAD3,
-        4: Keys.NUMPAD4, 5: Keys.NUMPAD5, 6: Keys.NUMPAD6,
-        7: Keys.NUMPAD7, 8: Keys.NUMPAD8, 9: Keys.NUMPAD9}
-
-except Exception as exception:
+            4: Keys.NUMPAD4, 5: Keys.NUMPAD5, 6: Keys.NUMPAD6,
+            7: Keys.NUMPAD7, 8: Keys.NUMPAD8, 9: Keys.NUMPAD9}
+except ImportError as exception:
     print_exception(exception)
 
 class BrowserManagement(object):
@@ -115,7 +114,9 @@ class BrowserManagement(object):
 
     def save_screenshot(self, browser_instance=None, filename=None,
                         directory=None):
-        """"""
+        """
+            Save screenshot of the specified/current browser
+        """
         status = True
         if browser_instance is None:
             browser_instance = self.current_browser
@@ -277,7 +278,8 @@ class BrowserManagement(object):
             element = browser_instance.find_element_by_tag_name("body")
             element.send_keys(Keys.LEFT_CONTROL, 't')
         sleep(1)
-        browser_instance.switch_to.window(browser_instance.window_handles[len(browser_instance.window_handles) - 1])
+        browser_instance.switch_to.window(browser_instance.window_handles\
+                                          [len(browser_instance.window_handles) - 1])
 
         if url is not None:
             self.go_to(url, browser_instance)
@@ -431,19 +433,26 @@ class BrowserManagement(object):
         return status
 
     def get_firefox_version(self, binary):
+        """
+            Use firefox binary to find out firefox version
+            before launching firefox in selenium
+        """
         if binary in [False, None]:
             binary = "firefox"
         version = False
         try:
             raw_version = check_output([binary, "-v"])
-            match = re.search("\d+\.\d+\.\d+", raw_version)
+            match = re.search(r"\d+\.\d+\.\d+", raw_version)
             if match is not None:
                 version = LooseVersion(match.group(0))
-        except CalledProcessError as e:
+        except CalledProcessError:
             print_error("Cannot find firefox version, will not launch browser")
         return version
 
     def get_browser_version(self, browser):
+        """
+            Get browser version from selenium
+        """
         # Return the browser version as string
         browser_version = browser.capabilities.get("version", None)
         if browser_version is None:
@@ -484,7 +493,8 @@ class BrowserManagement(object):
             browser = None
         else:
             kwargs["browser_name"] = browser_name
-            browser = creation_method(webdriver_remote_url, desired_capabilities, profile_dir, **kwargs)
+            browser = creation_method(webdriver_remote_url, desired_capabilities,
+                                      profile_dir, **kwargs)
             if browser is not None:
                 print_info("The {} browser version is {}".format(
                     browser_name, self.get_browser_version(browser)))
@@ -542,18 +552,19 @@ class BrowserManagement(object):
                 browser = webdriver.Firefox(firefox_binary=ffbinary,
                                             capabilities=ff_capabilities,
                                             firefox_profile=ff_profile, **optional_args)
-        except WebDriverException as e:
-            if "executable needs to be in PATH" in str(e):
+        except WebDriverException as err:
+            if "executable needs to be in PATH" in str(err):
                 print_error("Please provide path for geckodriver executable")
-            elif "Expected browser binary location" in str(e):
+            elif "Expected browser binary location" in str(err):
                 print_error("Please provide path of firefox executable")
-            print_error(e)
+            print_error(err)
             traceback.print_exc()
-        except Exception as e:
-            print_error(e)
+        except Exception as err:
+            print_error(err)
             traceback.print_exc()
 
-        if browser is None and any((LooseVersion(webdriver.__version__) < LooseVersion("3.5.0"), gecko_path is None)):
+        if browser is None and\
+           any((LooseVersion(webdriver.__version__) < LooseVersion("3.5.0"), gecko_path is None)):
             print_info("Unable to create Firefox browser, one possible reason is because"\
                        "Firefox version >= 47.0.1 and Selenium version < 3.5"\
                        "In order to launch Firefox ver 47 and up, Selenium needs to be updated to >= 3.5"\

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -513,6 +513,7 @@ class BrowserManagement(object):
                     webdriver.DesiredCapabilities.FIREFOX,
                     webdriver_remote_url, desired_capabilites, ff_profile)
             else:
+                optional_args = {}
                 ff_capabilities = webdriver.DesiredCapabilities.FIREFOX
                 # This is for internal testing needs...some https cert is not secure
                 ff_capabilities['acceptInsecureCerts'] = True
@@ -523,14 +524,14 @@ class BrowserManagement(object):
                 # https://github.com/SeleniumHQ/selenium/issues/5106#issuecomment-347298110
                 if self.get_firefox_version(binary) < LooseVersion("47.0.0"):
                     ff_capabilities["marionette"] = False
+                else:
+                    # gecko_log will only get generate if there is failure/error
+                    # Need to specify log_path for geckodriver log
+                    optional_args["log_path"] = log_dir
 
                 ffbinary = FirefoxBinary(binary) if binary is not None else None
-                optional_args = {}
                 if gecko_path is not None:
                     optional_args["executable_path"] = gecko_path
-                # gecko_log will only get generate if there is failure/error
-                optional_args["log_path"] = log_dir
-                # Need to specify log_path for geckodriver log
                 browser = webdriver.Firefox(firefox_binary=ffbinary,
                                             capabilities=ff_capabilities,
                                             firefox_profile=ff_profile, **optional_args)

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -226,9 +226,9 @@ class BrowserManagement(object):
                 browser_instance.get(url)
             else:
                 self.current_browser.get(url)
-        except WebDriverException, err:
+        except WebDriverException as err:
             print_error(err)
-            if "Reached error page" in err:
+            if "Reached error page" in str(err):
                 print_error("Unable to Navigate to URL:{}"\
                             "possibly because of the url is not valid".format(url))
             else:

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -262,18 +262,19 @@ class BrowserManagement(object):
         if browser_instance is None:
             browser_instance = self.current_browser
 
-        # only when firefox version < 47, open a new tab, otherwise open new window
+        # only when firefox version < 47, open new window
         if browser_type == "firefox" and\
            LooseVersion(self.get_browser_version(browser_instance)) < LooseVersion("47.0.0"):
             element = browser_instance.find_element_by_tag_name("body")
-            element.send_keys(Keys.LEFT_CONTROL, 't')
+            element.send_keys(Keys.LEFT_CONTROL, 'n')
         elif browser_type == "firefox":
             # If FF version > 47, this action is not supported
             print_error("Open tab operation is not supported in FF 47 or above")
             status = False
         else:
+            # if chrome, open a new tab
             element = browser_instance.find_element_by_tag_name("body")
-            element.send_keys(Keys.LEFT_CONTROL, 'n')
+            element.send_keys(Keys.LEFT_CONTROL, 't')
         sleep(1)
         browser_instance.switch_to.window(browser_instance.window_handles[len(browser_instance.window_handles) - 1])
 

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -226,10 +226,18 @@ class BrowserManagement(object):
                 browser_instance.get(url)
             else:
                 self.current_browser.get(url)
+        except WebDriverException, err:
+            print_error(err)
+            if "Reached error page" in err:
+                print_error("Unable to Navigate to URL:{}"\
+                            "possibly because of the url is not valid".format(url))
+            else:
+                status = False
         except Exception, err:
             print_error(err)
             status = False
             print_error("Unable to Navigate to URL:'%s'" % url)
+            traceback.print_exc()
         return status
 
     def reload_page(self, browser_instance=None):

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -442,9 +442,11 @@ class BrowserManagement(object):
         version = False
         try:
             raw_version = check_output([binary, "-v"])
-            match = re.search(r"\d+\.\d+\.\d+", raw_version)
+            match = re.search(r"\d+\.\d+", raw_version)
             if match is not None:
                 version = LooseVersion(match.group(0))
+            else:
+                print raw_version
         except CalledProcessError:
             print_error("Cannot find firefox version, will not launch browser")
         return version

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -17,6 +17,7 @@ import re
 import traceback
 from time import sleep
 import urllib2
+from distutils.version import LooseVersion
 from Framework.Utils.datetime_utils import get_current_timestamp
 from Framework.Utils.testcase_Utils import pNote
 from Framework.Utils.print_Utils import print_error, print_info, print_debug, print_exception,\
@@ -495,6 +496,12 @@ class BrowserManagement(object):
         except Exception as e:
             print_error(e)
             traceback.print_exc()
+
+        if browser is None and any((LooseVersion(webdriver.__version__) < LooseVersion("3.5.0"), gecko_path is None)):
+            print_info("Unable to create Firefox browser, one possible reason is because"\
+                       "Firefox version >= 47.0.1 and Selenium version < 3.5"\
+                       "In order to launch Firefox ver 47 and up, Selenium needs to be updated to >= 3.5"\
+                       "and needs geckodriver > 0.16")
 
         return browser
 

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -14,6 +14,7 @@ limitations under the License.
 """ selenium browser management library"""
 import os
 import re
+import traceback
 from time import sleep
 import urllib2
 from Framework.Utils.datetime_utils import get_current_timestamp
@@ -470,8 +471,10 @@ class BrowserManagement(object):
             elif "Expected browser binary location" in str(e):
                 print_error("Please provide path of firefox executable")
             print_error(e)
+            traceback.print_exc()
         except Exception as e:
             print_error(e)
+            traceback.print_exc()
 
         return browser
 

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -261,9 +261,14 @@ class BrowserManagement(object):
         if browser_instance is None:
             browser_instance = self.current_browser
 
-        if browser_type == "firefox":
+        # only when firefox version < 47, open a new tab, otherwise open new window
+        if browser_type == "firefox" and\
+           LooseVersion(self.get_browser_version(browser_instance)) < LooseVersion("47.0.0"):
             element = browser_instance.find_element_by_tag_name("body")
             element.send_keys(Keys.LEFT_CONTROL, 'n')
+        elif browser_type == "firefox":
+            # If FF version > 47, this action is not supported
+            raise Exception
         else:
             element = browser_instance.find_element_by_tag_name("body")
             element.send_keys(Keys.LEFT_CONTROL, 't')

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -445,6 +445,7 @@ class BrowserManagement(object):
         gecko_path = kwargs.get("gecko_path", None)
         proxy_ip = kwargs.get("proxy_ip", None)
         proxy_port = kwargs.get("proxy_port", None)
+        ff_profile = None
         if proxy_ip is not None and proxy_port is not None:
             ff_profile = self.set_firefox_proxy(profile_dir, proxy_ip, proxy_port)
         # Need to check binary and gecko_path value
@@ -460,11 +461,13 @@ class BrowserManagement(object):
                 ff_capabilities = webdriver.DesiredCapabilities.FIREFOX
                 # This is for internal testing needs...
                 ff_capabilities['acceptInsecureCerts'] = True
-                ffbinary = FirefoxBinary(binary)
+                ffbinary = FirefoxBinary(binary) if binary is not None else None
+                optional_args = {}
+                if gecko_path is not None:
+                    optional_args["executable_path"] = gecko_path
                 browser = webdriver.Firefox(firefox_binary=ffbinary,
                                             capabilities=ff_capabilities,
-                                            firefox_profile=ff_profile,
-                                            executable_path=gecko_path)
+                                            firefox_profile=ff_profile, **optional_args)
         except WebDriverException as e:
             if "executable needs to be in PATH" in str(e):
                 print_error("Please provide path for geckodriver executable")

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -55,7 +55,7 @@ class BrowserManagement(object):
             print_debug("Opening browser '%s'" % (browser_name))
         browser_name = browser_name
         browser = self._make_browser(browser_name, desired_capabilities,
-                                     profile_dir, webdriver_remote_url)
+                                     profile_dir, webdriver_remote_url, **kwargs)
         return browser
 
     def close_browser(self, browser_instance=None):
@@ -401,7 +401,7 @@ class BrowserManagement(object):
 
     # private methods
     def _make_browser(self, browser_name, desired_capabilities=None,
-                      profile_dir=None, webdriver_remote_url=None):
+                      profile_dir=None, webdriver_remote_url=None, **kwargs):
         """method to open a browser, calls other sepcific/generic
         make browser methods to open a browser """
         creation_func = self._get_browser_creation_function(browser_name)
@@ -410,7 +410,7 @@ class BrowserManagement(object):
             raise ValueError("{} is not a supported browser. Please use firefox or chrome".\
                              format(browser_name))
 
-        browser = creation_func(webdriver_remote_url, desired_capabilities, profile_dir)
+        browser = creation_func(webdriver_remote_url, desired_capabilities, profile_dir, **kwargs)
         return browser
 
     def _get_browser_creation_function(self, browser_name):
@@ -421,7 +421,7 @@ class BrowserManagement(object):
         return getattr(self, func_name) if func_name else None
 
 
-    def _make_ff(self, webdriver_remote_url, desired_capabilites, profile_dir):
+    def _make_ff(self, webdriver_remote_url, desired_capabilites, profile_dir, **kwargs):
         """Create an instance of firefox browser"""
 
         if webdriver_remote_url:
@@ -432,15 +432,15 @@ class BrowserManagement(object):
             browser = webdriver.Firefox(firefox_profile=profile_dir)
         return browser
 
-    def _make_chrome(self, webdriver_remote_url, desired_capabilities, profile_dir):
+    def _make_chrome(self, webdriver_remote_url, desired_capabilities, profile_dir, **kwargs):
         """Creates an instance of chrome browser and returns it
         Need to have selenium chrome driver exe placed in the python path"""
         return self._generic_make_browser(webdriver.Chrome,
                                           webdriver.DesiredCapabilities.CHROME,
-                                          webdriver_remote_url, desired_capabilities)
+                                          webdriver_remote_url, desired_capabilities, **kwargs)
 
     def _generic_make_browser(self, webdriver_type, desired_cap_type,
-                              webdriver_remote_url, desired_caps):
+                              webdriver_remote_url, desired_caps, **kwargs):
         """most of the make browser functions just call this function which creates the
         appropriate web-driver"""
         if not webdriver_remote_url:

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -25,6 +25,7 @@ from Framework.Utils.print_Utils import print_error, print_info, print_debug, pr
 
 try:
     from selenium import webdriver
+    print_info("The Selenium Webdriver version is '{0}'".format(webdriver.__version__))
     from selenium.webdriver import ActionChains
     from selenium.webdriver.common.keys import Keys
     from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
@@ -432,21 +433,25 @@ class BrowserManagement(object):
                       profile_dir=None, webdriver_remote_url=None, **kwargs):
         """method to open a browser, calls other sepcific/generic
         make browser methods to open a browser """
-        creation_func = self._get_browser_creation_function(browser_name)
+        browser_methods = {'ff': self._make_ff, 'firefox': self._make_ff, 'chrome': self._make_chrome}
+        creation_method = browser_methods.get(browser_name, None)
 
-        if creation_func is None:
-            raise ValueError("{} is not a supported browser. Please use firefox or chrome".\
+        if creation_method is None:
+            print_error("{} is not a supported browser. Please use firefox or chrome".\
                              format(browser_name))
+            browser = None
+        else:
+            browser = creation_method(webdriver_remote_url, desired_capabilities, profile_dir, **kwargs)
+            if browser is not None:
+                print_info("The {} browser version is {}".format(browser_name, self.get_browser_version(browser)))
+            else:
+                print_error("Unable to create browser for: {}".format(browser_name))
 
-        browser = creation_func(webdriver_remote_url, desired_capabilities, profile_dir, **kwargs)
         return browser
 
     def _get_browser_creation_function(self, browser_name):
         """Gets the browser function for the supported browsers
         from the browser_methods dictionary """
-        browser_methods = {'ff': "_make_ff", 'firefox': "_make_ff", 'chrome': "_make_chrome"}
-        func_name = browser_methods.get(browser_name.lower().replace(' ', ''))
-        return getattr(self, func_name) if func_name else None
 
 
     def _make_ff(self, webdriver_remote_url, desired_capabilites, profile_dir, **kwargs):

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -97,16 +97,16 @@ class BrowserManagement(object):
         """Maximizes current browser window."""
         status = True
         try:
-            if browser_instance is not None:
-                # Need to distinguish whether browser is in headless mode or not
-                # as maximize_window doesn't work in headless mode
-                if headless_mode:
-                    browser_instance.set_window_size(1920, 1080)
-                else:
-                    browser_instance.maximize_window()
+            if browser_instance is None:
+                browser_instance = self.current_browser
 
+            # Need to distinguish whether browser is in headless mode or not
+            # as maximize_window doesn't work in headless mode
+            if headless_mode:
+                browser_instance.set_window_size(1920, 1080)
             else:
-                self.current_browser.maximize_window()
+                browser_instance.maximize_window()
+
         except Exception as exception:
             print_exception(exception)
             status = False

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -502,7 +502,7 @@ class BrowserManagement(object):
                 optional_args = {}
                 if gecko_path is not None:
                     optional_args["executable_path"] = gecko_path
-                print ff_capabilities, optional_args
+                # Need to specify log_path for geckodriver log
                 browser = webdriver.Firefox(firefox_binary=ffbinary,
                                             capabilities=ff_capabilities,
                                             firefox_profile=ff_profile, **optional_args)

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -23,6 +23,7 @@ from Framework.Utils.datetime_utils import get_current_timestamp
 from Framework.Utils.testcase_Utils import pNote
 from Framework.Utils.print_Utils import print_error, print_info, print_debug, print_exception,\
     print_warning
+from Framework.Utils.data_Utils import get_object_from_datarepository
 
 
 try:
@@ -448,7 +449,8 @@ class BrowserManagement(object):
                       profile_dir=None, webdriver_remote_url=None, **kwargs):
         """method to open a browser, calls other sepcific/generic
         make browser methods to open a browser """
-        browser_methods = {'ff': self._make_ff, 'firefox': self._make_ff, 'chrome': self._make_chrome}
+        browser_methods = {'ff': self._make_ff, 'firefox': self._make_ff,
+                           'chrome': self._make_chrome}
         creation_method = browser_methods.get(browser_name, None)
 
         if creation_method is None:
@@ -456,9 +458,11 @@ class BrowserManagement(object):
                              format(browser_name))
             browser = None
         else:
+            kwargs["browser_name"] = browser_name
             browser = creation_method(webdriver_remote_url, desired_capabilities, profile_dir, **kwargs)
             if browser is not None:
-                print_info("The {} browser version is {}".format(browser_name, self.get_browser_version(browser)))
+                print_info("The {} browser version is {}".format(
+                    browser_name, self.get_browser_version(browser)))
             else:
                 print_error("Unable to create browser for: {}".format(browser_name))
 
@@ -478,7 +482,10 @@ class BrowserManagement(object):
         ff_profile = None
         if proxy_ip is not None and proxy_port is not None:
             ff_profile = self.set_firefox_proxy(profile_dir, proxy_ip, proxy_port)
-        # Need to check firefox version
+
+        log_dir = get_object_from_datarepository("wt_logsdir") if \
+                  kwargs.get("log_path") in [None, False] else kwargs.get("log_path")
+        log_dir = os.path.join(log_dir, "gecko_"+kwargs.get("browser_name", "default")+".log")
 
         browser = None
         try:
@@ -502,6 +509,7 @@ class BrowserManagement(object):
                 optional_args = {}
                 if gecko_path is not None:
                     optional_args["executable_path"] = gecko_path
+                optional_args["log_path"] = log_dir
                 # Need to specify log_path for geckodriver log
                 browser = webdriver.Firefox(firefox_binary=ffbinary,
                                             capabilities=ff_capabilities,

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -258,6 +258,7 @@ class BrowserManagement(object):
 
     def open_tab(self, browser_instance=None, url=None, browser_type="firefox"):
         """Opens a new tab in the browser"""
+        status = True
         if browser_instance is None:
             browser_instance = self.current_browser
 
@@ -268,7 +269,8 @@ class BrowserManagement(object):
             element.send_keys(Keys.LEFT_CONTROL, 't')
         elif browser_type == "firefox":
             # If FF version > 47, this action is not supported
-            raise RuntimeError("Open tab operation is not supported in FF 47 or above")
+            print_error("Open tab operation is not supported in FF 47 or above")
+            status = False
         else:
             element = browser_instance.find_element_by_tag_name("body")
             element.send_keys(Keys.LEFT_CONTROL, 'n')
@@ -278,6 +280,8 @@ class BrowserManagement(object):
         if url is not None:
             self.go_to(url, browser_instance)
             sleep(1)
+
+        return status
 
     def switch_tab(self, browser_instance=None, tab_number=None, browser_type="firefox"):
         """Switching to different tabs in a browser with unique tab_number"""

--- a/warrior/Framework/Utils/selenium_Utils.py
+++ b/warrior/Framework/Utils/selenium_Utils.py
@@ -444,6 +444,7 @@ def create_display():
     status = True
     try:
         from pyvirtualdisplay import Display
+        # Selenium has problem with firefox in virtualdisplay if resolution is low
         display = Display(visible=0, size=(1920, 1080))
         display.start()
         print_info("Running in headless mode")

--- a/warrior/Framework/Utils/selenium_Utils.py
+++ b/warrior/Framework/Utils/selenium_Utils.py
@@ -442,6 +442,8 @@ def get_element_from_config_file(config_file, element_tag, child_tag,
 
 def create_display():
     status = True
+    if data_Utils.get_object_from_datarepository("headless_display"):
+        return status
     try:
         from pyvirtualdisplay import Display
         # Selenium has problem with firefox in virtualdisplay if resolution is low

--- a/warrior/Framework/Utils/selenium_Utils.py
+++ b/warrior/Framework/Utils/selenium_Utils.py
@@ -439,3 +439,20 @@ def get_element_from_config_file(config_file, element_tag, child_tag,
         else:
             final_value = None
     return final_value
+
+def create_display():
+    status = True
+    try:
+        from pyvirtualdisplay import Display
+        display = Display(visible=0, size=(1920, 1080))
+        display.start()
+        print_info("Running in headless mode")
+    except ImportError:
+        print_error("pyvirtualdisplay is not installed in order "
+                    "to launch the browser in headless mode")
+        status = False
+    except Exception as e:
+        print_error("Encountered Exception: {0}, while trying to launch the browser"
+                    " in headless mode".format(e))
+        status = False
+    return status

--- a/warrior/Framework/Utils/selenium_Utils.py
+++ b/warrior/Framework/Utils/selenium_Utils.py
@@ -441,6 +441,11 @@ def get_element_from_config_file(config_file, element_tag, child_tag,
     return final_value
 
 def create_display():
+    """
+        Create a virtual display
+        Default size is 1920x1080 as smaller resolution
+        may cause problem in firefox
+    """
     status = True
     if data_Utils.get_object_from_datarepository("headless_display"):
         return status
@@ -454,8 +459,8 @@ def create_display():
         print_error("pyvirtualdisplay is not installed in order "
                     "to launch the browser in headless mode")
         status = False
-    except Exception as e:
+    except Exception as err:
         print_error("Encountered Exception: {0}, while trying to launch the browser"
-                    " in headless mode".format(e))
+                    " in headless mode".format(err))
         status = False
     return status

--- a/warrior/Warrior
+++ b/warrior/Warrior
@@ -79,7 +79,7 @@ def update_jira_by_id(jiraproj, jiraid, exec_dir, status):
     else:
         print_info("jiraid not provided, will not update jira issue")
 
-def main(parameter_list, a_defects, cse_execution, iron_claw, jiraproj, overwrite, jiraid, dbsystem):
+def main(parameter_list, a_defects, cse_execution, iron_claw, jiraproj, overwrite, jiraid, dbsystem, headless):
     """Parses the input parameters (i.e. sys.argv)
         If the input parameter is an xml file:
             - check if file exists, if exists
@@ -122,6 +122,8 @@ def main(parameter_list, a_defects, cse_execution, iron_claw, jiraproj, overwrit
                         default_repo.update({'db_obj': db_obj})
                     else:
                         default_repo.update({'db_obj': False})
+
+                    default_repo["wt_enable_headless"] = True if headless else False
 
                     if Utils.xml_Utils.getRoot(abs_filepath).tag == 'Testcase':
                         default_repo['war_file_type'] = "Case"
@@ -168,14 +170,14 @@ def main(parameter_list, a_defects, cse_execution, iron_claw, jiraproj, overwrit
 if __name__ == '__main__':
 
     FILEPATH, AUTO_DEFECTS, version, CSE_EXEC, IRON_CLAW, JIRAPROJ, \
-    OVERWRITE, JIRAID, DBSYSTEM = warrior_cli_driver.main(sys.argv[1:])
+    OVERWRITE, JIRAID, DBSYSTEM, HEADLESS = warrior_cli_driver.main(sys.argv[1:])
     if version:
         framework_detail.warrior_framework_details()
         sys.exit(0)
     if not CSE_EXEC and len(FILEPATH) == 0:
         print_error("Provide atleast one xml file to execute")
     status = main(FILEPATH, AUTO_DEFECTS, CSE_EXEC, IRON_CLAW,
-                  JIRAPROJ, OVERWRITE, JIRAID, DBSYSTEM)
+                  JIRAPROJ, OVERWRITE, JIRAID, DBSYSTEM, HEADLESS)
     status = {"true": True, "pass": True, "ran": "RAN"}.get(str(status).lower())
     if status is True or status == "RAN":
         print_info("DONE 0")

--- a/warrior/WarriorCore/Classes/war_cli_class.py
+++ b/warrior/WarriorCore/Classes/war_cli_class.py
@@ -397,6 +397,10 @@ class WarriorCliClass(object):
                             "or other CLI related operation."
                             "User can verify input value from console output/result file")
 
+        parser.add_argument('-headless', action='store_true', default=False,
+                            help="If headless mode is enabled, all selenium tests will run in xfvb "\
+                            "which will not need a GUI")
+
         namespace = parser.parse_args(arglist)
         #see if the below line is requried
         if namespace.mock:

--- a/warrior/WarriorCore/warrior_cli_driver.py
+++ b/warrior/WarriorCore/warrior_cli_driver.py
@@ -216,7 +216,7 @@ def decide_action(w_cli_obj, namespace):
     # print filepath
     return (filepath, namespace.ad, namespace.version,
             namespace.cse, namespace.ironclaw, namespace.jiraproj, overwrite,
-            namespace.jiraid, namespace.dbsystem)
+            namespace.jiraid, namespace.dbsystem, namespace.headless)
 
 
 def main(args):

--- a/wftests/warrior_tests/data/selenium_func_tests/data_selenium_headless.xml
+++ b/wftests/warrior_tests/data/selenium_func_tests/data_selenium_headless.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<credentials>   
+    <system name="search_element_1">
+        <headless_mode>yes</headless_mode>
+        <browser>
+            <browser_name>browser_1</browser_name>
+            <type>firefox</type>
+        </browser>
+    </system>
+    <system name="search_element_2">
+        <headless_mode>yes</headless_mode>
+        <browser>
+            <browser_name>browser_2</browser_name>
+            <type>chrome</type>
+        </browser>
+    </system>
+</credentials>

--- a/wftests/warrior_tests/testcases/selenium_tests/tc_selenium_headless.xml
+++ b/wftests/warrior_tests/testcases/selenium_tests/tc_selenium_headless.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+            <Name>tc_selenium_headless</Name>
+            <Title>Test case to only run in system without GUI to test headless mode functionality</Title>
+            <ExpectedResults>PASS</ExpectedResults>
+            <Category>search</Category>
+            <Engineer>Ka Hei Chan</Engineer>
+            <Date/>
+            <Time/>
+            <default_onError action = 'next'  />
+            <InputDataFile>../../data/selenium_func_tests/data_selenium_headless.xml</InputDataFile>
+            <Datatype>Custom</Datatype>
+            <Logsdir/>
+            <Resultsdir/>
+        </Details>
+       <Requirements>
+                <Requirement>requirement-001</Requirement>
+                <Requirement>requirement-002</Requirement>
+       </Requirements>
+        <Steps>
+            <step TS= '1' Driver='selenium_driver' Keyword='browser_launch' >
+                <Arguments>
+                    <argument name="system_name" value="search_element_1"/>
+                    <argument name="url" value="http://www.google.com"/>
+                </Arguments>
+            </step>
+            <step TS= '2' Driver='selenium_driver' Keyword='browser_maximize' >
+                <Arguments>
+                    <argument name="system_name" value="search_element_1"/>
+                </Arguments>
+            </step>
+            <step TS= '3' Driver='selenium_driver' Keyword='browser_close' >
+                <Arguments>
+                    <argument name="system_name" value="search_element_1"/>
+                </Arguments>
+            </step>
+            <step TS= '4' Driver='selenium_driver' Keyword='browser_launch' >
+                <Arguments>
+                    <argument name="system_name" value="search_element_2"/>
+                    <argument name="url" value="http://www.google.com"/>
+                </Arguments>
+            </step>
+            <step TS= '5' Driver='selenium_driver' Keyword='browser_maximize' >
+                <Arguments>
+                    <argument name="system_name" value="search_element_2"/>
+                </Arguments>
+            </step>
+            <step TS= '6' Driver='selenium_driver' Keyword='browser_close' >
+                <Arguments>
+                    <argument name="system_name" value="search_element_2"/>
+                </Arguments>
+            </step>
+        </Steps>
+</Testcase>


### PR DESCRIPTION
Due to #62 and #133 changes which cause instability to the platform as the code logic is flawed
This PR revert those changes and will provide a stable release

This ticket also includes changes for WAR-1591
and necessary support for WAR-1074 to run correctly

With firefox version 47 and above, a geckodriver is needed in the local sys env path
https://github.com/mozilla/geckodriver/releases
Chrome needs chromedriver
https://sites.google.com/a/chromium.org/chromedriver/downloads

if geckodriver is needed, then selenium version needs to be 3.5 or above
https://github.com/mozilla/geckodriver#selenium
which means for Firefox 47 and above, warrior needs both geckodriver and selenium >= 3.5 to run
Chrome isn't affected

For geckodriver launched firefox
currently found that browser.capabilities dict has "browserVersion" instead of "version"
needs to handle this kind of key changes in warriorframework

Test files are updated in internal repo

**Code is ready to be reviewed**
  