### PR TITLE
WAR:1583 - Incorrect Results printed on Console window for iterative Parallel TC

### DIFF
--- a/warrior/WarriorCore/iterative_parallel_testcase_driver.py
+++ b/warrior/WarriorCore/iterative_parallel_testcase_driver.py
@@ -50,7 +50,8 @@ def execute_iterative_parallel_testcases(system_list, testcase_list, suite_repos
                                   ("auto_defects", auto_defects),
                                   ("system", system),
                                   ("tc_parallel", tc_parallel),
-                                  ("output_q", output_q)
+                                  ("output_q", output_q),
+                                  ("ts_iter", True)
                                   ])
 
         process, jobs_list, output_q = create_and_start_process_with_queue(target_module, tc_args_dict, jobs_list, output_q)
@@ -76,7 +77,7 @@ def execute_iterative_parallel_testcases(system_list, testcase_list, suite_repos
             tc_name_list.append(result[1])
             tc_impact_list.append(result[2][val])
             tc_duration_list.append(result[3][val])
-            tc_junit_list.append(result[4][val])
+        tc_junit_list.append(result[4])
     # parallel testcases generate multiple testcase junit result files
     # each files log the result for one testcase and not intergrated
     # update testsuite junit result file with individual testcase result files

--- a/warrior/WarriorCore/iterative_parallel_testcase_driver.py
+++ b/warrior/WarriorCore/iterative_parallel_testcase_driver.py
@@ -11,27 +11,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 
+import traceback
+from collections import OrderedDict
+
+import Framework.Utils as Utils
+from Framework.Utils.print_Utils import print_error, print_debug
+from WarriorCore.multiprocessing_utils import create_and_start_process_with_queue, \
+ get_results_from_queue, update_ts_junit_resultfile
+from WarriorCore import sequential_testcase_driver
 
 """
 This is  iterative parallel testcase driver which is used to execute
 the testcases of a suite in parallely across the systems in the suite data file
 """
 
-import os
-import traceback
-from collections import OrderedDict
-
-
-import testcase_driver
-import Framework.Utils as Utils
-from Framework.Utils.print_Utils import print_error, print_debug
-from WarriorCore.multiprocessing_utils import create_and_start_process_with_queue, \
-get_results_from_queue, update_ts_junit_resultfile
-from WarriorCore import testsuite_utils, sequential_testcase_driver
 
 def execute_iterative_parallel_testcases(system_list, testcase_list, suite_repository,
-                               data_repository, from_project, tc_parallel=True,
-                               auto_defects=False):
+                                         data_repository, from_project, tc_parallel=True,
+                                         auto_defects=False):
     """Takes a list of systems as input and executes the testcases in parallel by
     creating separate process of testcase_driver for each of these systems """
 
@@ -40,21 +37,19 @@ def execute_iterative_parallel_testcases(system_list, testcase_list, suite_repos
 
     for system in system_list:
         target_module = sequential_testcase_driver.main
-        
-        #args_list = [testcase_list, suite_repository, data_repository, from_project,
-        #             auto_defects, system, tc_parallel]    
         tc_args_dict = OrderedDict([("testcase_list", testcase_list),
-                                  ("suite_repository", suite_repository),
-                                  ("data_repository", data_repository),
-                                  ("from_project", from_project),
-                                  ("auto_defects", auto_defects),
-                                  ("system", system),
-                                  ("tc_parallel", tc_parallel),
-                                  ("output_q", output_q),
-                                  ("ts_iter", True)
-                                  ])
+                                    ("suite_repository", suite_repository),
+                                    ("data_repository", data_repository),
+                                    ("from_project", from_project),
+                                    ("auto_defects", auto_defects),
+                                    ("system", system),
+                                    ("tc_parallel", tc_parallel),
+                                    ("output_q", output_q),
+                                    ("ts_iter", True)
+                                    ])
 
-        process, jobs_list, output_q = create_and_start_process_with_queue(target_module, tc_args_dict, jobs_list, output_q)
+        process, jobs_list, output_q = create_and_start_process_with_queue(
+         target_module, tc_args_dict, jobs_list, output_q)
 
     print_debug("process: {0}".format(process))
     for job in jobs_list:
@@ -66,7 +61,8 @@ def execute_iterative_parallel_testcases(system_list, testcase_list, suite_repos
     tc_name_list = []
     tc_impact_list = []
     tc_duration_list = []
-    # Get the junit object of each testcase, extract the information from it and combine with testsuite junit object
+    # Get the junit object of each testcase, extract the information from it
+    # and combine with testsuite junit object
     tc_junit_list = []
 
     # Suite results
@@ -87,15 +83,14 @@ def execute_iterative_parallel_testcases(system_list, testcase_list, suite_repos
     return testsuite_status
 
 
-def main(system_list, testcase_list, suite_repository, data_repository, from_project, tc_parallel=False,
-         auto_defects=False):
+def main(system_list, testcase_list, suite_repository, data_repository,
+         from_project, tc_parallel=False, auto_defects=False):
     """Executes the list of testcases in parallel
     Computes and returns the testsuite status"""
     try:
-        testsuite_status = execute_iterative_parallel_testcases(system_list, testcase_list, suite_repository,
-                                                                data_repository,
-                                                                from_project, tc_parallel,
-                                                                auto_defects)
+        testsuite_status = execute_iterative_parallel_testcases(
+         system_list, testcase_list, suite_repository, data_repository,
+         from_project, tc_parallel, auto_defects)
     except Exception:
         testsuite_status = False
         print_error('unexpected error {0}'.format(traceback.format_exc()))

--- a/warrior/WarriorCore/sequential_testcase_driver.py
+++ b/warrior/WarriorCore/sequential_testcase_driver.py
@@ -13,9 +13,6 @@ limitations under the License.
 
 #!/usr/bin/python
 
-"""This is sequential testcase driver which is used to execute
-the testcases of a suite in sequential order"""
-
 import os
 import time
 import traceback
@@ -27,33 +24,42 @@ from Framework.Utils.print_Utils import print_info, print_error, print_debug, pr
 from WarriorCore import testsuite_utils, common_execution_utils
 import exec_type_driver
 
+"""This is sequential testcase driver which is used to execute
+the testcases of a suite in sequential order"""
+
+
 def update_suite_attribs(junit_resultfile, errors, skipped,
                          tests, failures, time='0'):
     """Update suite attributes """
     testsuite_utils.pSuite_update_suite_attributes(junit_resultfile, str(errors),
-                                                         str(skipped), str(tests), str(failures),
-                                                         time)
+                                                   str(skipped), str(tests), str(failures), time)
 
 
 def execute_sequential_testcases(testcase_list, suite_repository,
                                  data_repository, from_project, auto_defects,
                                  iter_ts_sys, tc_parallel, queue, ts_iter):
-    """Executes the testsuite (provided as a xml file)
-            - Takes a testsuite xml file as input and sends
-            each testcase to Basedriver for execution.
-            - Computes the testsuite status based on the testcase_status
-            and the impact value of the testcase
-            - Handles testcase failures as per the default/specific
-            onError action/value
-            - Calls the function to report the testsuite status
+    """Executes the list of cases(of a suite) in sequential order
+        - Takes a testcase_list as input and sends
+        each case to Basedriver for execution.
+        - Computes the suite status based on the case_status
+        and the impact value of the case
+        - Handles case failures as per the default/specific
+        onError action/value
+        - Calls the function to report the suite status
 
-    Arguments:
-    1. testsuite_filepath   = (string) the full path of the testsuite xml file.
-    2. Warrior      = (module loader) module loader object to call the Warrior
-    3. execution_dir  = (string) the full path of the directory under which
-    the testsuite execution directory will be created
-    (results for the testsuite will be stored in the  testsuite execution
-    directory.)
+    :Arguments:
+        1. testcase_list(list) = List of cases to be executed
+        2. suite_repository(dict) = suite repository
+        3. data_repository(dict) = Warrior data repository
+        4. from_project(boolean) = True for Project execution else False
+        5. auto_defects(boolean) = True for Jira auto defect creation else False
+        6. iter_ts_sys(string) = System for iterative execution
+        7. tc_parallel(boolean) = True for Parallel execution else False
+        8. queue = Python multiprocessing queue for parallel execution
+        9. ts_iter(boolean) = True for 'iterative_parallel' execution else False
+    :Returns:
+        1. suite_status - overall suite status
+
     """
     goto_tc = False
 
@@ -102,10 +108,12 @@ def execute_sequential_testcases(testcase_list, suite_repository,
                                                     testsuite_dir)
             data_repository[tc_path] = data_file
         data_repository['wt_tc_impact'] = tc_impact
-        if testcase.find("runmode") is not None and testcase.find("runmode").get("attempt") is not None:
+        if testcase.find("runmode") is not None and \
+           testcase.find("runmode").get("attempt") is not None:
             print_info("testcase attempt: {0}".format(
                                 testcase.find("runmode").get("attempt")))
-        if testcase.find("retry") is not None and testcase.find("retry").get("attempt") is not None:
+        if testcase.find("retry") is not None and \
+           testcase.find("retry").get("attempt") is not None:
             print_info("testcase attempt: {0}".format(
                                 testcase.find("retry").get("attempt")))
 
@@ -137,14 +145,14 @@ def execute_sequential_testcases(testcase_list, suite_repository,
             elif goto_tc and goto_tc == str(tests) and action is True:
 
                 try:
-                    tc_result= testcase_driver.main(tc_path,
-                                                    data_repository,
-                                                    tc_context,
-                                                    runtype=tc_runtype,
-                                                    auto_defects=auto_defects,
-                                                    suite=suite_name,
-                                                    tc_onError_action=tc_onError_action,
-                                                    iter_ts_sys=iter_ts_sys)
+                    tc_result = testcase_driver.main(tc_path,
+                                                     data_repository,
+                                                     tc_context,
+                                                     runtype=tc_runtype,
+                                                     auto_defects=auto_defects,
+                                                     suite=suite_name,
+                                                     tc_onError_action=tc_onError_action,
+                                                     iter_ts_sys=iter_ts_sys)
                     tc_status = tc_result[0]
                     tc_duration = tc_result[1]
                     goto_tc = False
@@ -251,7 +259,8 @@ def execute_sequential_testcases(testcase_list, suite_repository,
 
         runmode, value, _ = common_execution_utils.get_runmode_from_xmlfile(
                                                                 testcase)
-        retry_type, retry_cond, retry_cond_value, retry_value, retry_interval = common_execution_utils.get_retry_from_xmlfile(testcase)
+        retry_type, retry_cond, retry_cond_value, retry_value, \
+            retry_interval = common_execution_utils.get_retry_from_xmlfile(testcase)
         if runmode is not None:
             if tc_status is True:
                 testsuite_utils.update_tc_duration(str(tc_duration))

--- a/warrior/WarriorCore/sequential_testcase_driver.py
+++ b/warrior/WarriorCore/sequential_testcase_driver.py
@@ -37,7 +37,7 @@ def update_suite_attribs(junit_resultfile, errors, skipped,
 
 def execute_sequential_testcases(testcase_list, suite_repository,
                                  data_repository, from_project, auto_defects,
-                                 iter_ts_sys, tc_parallel, queue):
+                                 iter_ts_sys, tc_parallel, queue, ts_iter):
     """Executes the testsuite (provided as a xml file)
             - Takes a testsuite xml file as input and sends
             each testcase to Basedriver for execution.
@@ -356,7 +356,15 @@ def execute_sequential_testcases(testcase_list, suite_repository,
         update_suite_attribs(junit_resultfile, str(errors),
                              str(skipped), str(tests), str(failures),
                              time='0')
-        tc_junit_list.append(data_repository['wt_junit_object'])
+        # junit_object/python_process is different for all the cases
+        # executed in parallel
+        if ts_iter is False:
+            tc_junit_list.append(data_repository['wt_junit_object'])
+
+    # junit_object/python_process is same for all the cases executed in the
+    # same system for 'iterative_parallel' suite execution
+    if ts_iter is True:
+        tc_junit_list = data_repository['wt_junit_object']
 
     suite_status = Utils.testcase_Utils.compute_status_using_impact(
                                         tc_status_list, tc_impact_list)
@@ -375,13 +383,15 @@ def execute_sequential_testcases(testcase_list, suite_repository,
                    tc_junit_list))
     return suite_status
 
-def main(testcase_list, suite_repository,
-         data_repository, from_project, auto_defects, iter_ts_sys=None, tc_parallel=False, queue=False):
+
+def main(testcase_list, suite_repository, data_repository, from_project,
+         auto_defects, iter_ts_sys=None, tc_parallel=False, queue=False,
+         ts_iter=False):
     """Executes testcases in a testsuite sequentially """
     try:
-        testsuite_status = execute_sequential_testcases(testcase_list, suite_repository,
-                                                        data_repository,
-                                                        from_project, auto_defects, iter_ts_sys, tc_parallel, queue)
+        testsuite_status = execute_sequential_testcases(
+         testcase_list, suite_repository, data_repository, from_project,
+         auto_defects, iter_ts_sys, tc_parallel, queue, ts_iter)
     except Exception:
         testsuite_status = False
         print_error('unexpected error {0}'.format(traceback.format_exc()))


### PR DESCRIPTION
Issue - Duplicate entries in the execution summary when executing 'iterative_parallel' suite.
Reason - Same junit object is being added multiple times to the multiprocessing queue during 'iterative_parallel' suite execution.
Fix - junit_object/python_process is same for all the cases executed in the same system for 'iterative_parallel' suite execution so do not append junit object into queue for all the cases(just add once).  Code changes are in 5a83b8c, rest are pylint fixes.

How to test - Run any suite with exectype as 'ITERATIVE_PARALLEL' with more than one system in a data_file(test use-case and regression results are in the jira ticket).