### PR TITLE
WAR-1680 : Using context as negative in connect_netconf keyword is giving EXCEPTION error

### DIFF
--- a/warrior/Framework/ClassUtils/netconf_utils_class.py
+++ b/warrior/Framework/ClassUtils/netconf_utils_class.py
@@ -66,6 +66,9 @@ class WNetConf(object):
                                               nc_session['password'],
                                               nc_session['hostkey_verify'],
                                               nc_session['protocol_version'])
+            # If connection fails return False
+            if self.nc_manager is None:
+                return False
         except:
             traceback.print_exc()
             return False


### PR DESCRIPTION
Issue: Due to the changes in #92, netconf.connect returns None when authentication fails during connection establishment and this needs to be handled in the calling method(s).
Fix: Return False if connection fails in the 'open' method of 'netconf_utils_class.py'

How to test: Run any netconf tests(conenct_netconf kw is enough) with wrong password in the data file. connect_netconf kw was throwing exception earlier, now it is handled correctly and the kw status will be set to False.