### PR TITLE
WAR-1687 (develop) : Execute multiple test cases via command line by specifying input data file - bugfix

### DIFF
--- a/warrior/Warrior
+++ b/warrior/Warrior
@@ -166,6 +166,7 @@ def main(parameter_list, a_defects, cse_execution, iron_claw, jiraproj, overwrit
             db_obj.close_connection()
     return status
 
+
 if __name__ == '__main__':
 
     FILEPATH, AUTO_DEFECTS, version, CSE_EXEC, IRON_CLAW, JIRAPROJ, \

--- a/warrior/Warrior
+++ b/warrior/Warrior
@@ -105,6 +105,7 @@ def main(parameter_list, a_defects, cse_execution, iron_claw, jiraproj, overwrit
         status = True
         db_obj = database_utils_class.create_database_connection(dbsystem=dbsystem)
         for parameter in parameter_list:
+            default_repo = {}
             result = False
             # check if the input parameter is an xml file
             if Utils.file_Utils.get_extension_from_path(parameter) == '.xml':
@@ -114,9 +115,7 @@ def main(parameter_list, a_defects, cse_execution, iron_claw, jiraproj, overwrit
                 print_info('Absolute path: {0}'.format(abs_filepath))
                 if Utils.file_Utils.fileExists(abs_filepath):
                     if len(overwrite.items()) > 0:
-                        default_repo = overwrite
-                    else:
-                        default_repo = {}
+                        default_repo.update(overwrite)
 
                     if db_obj is not False and db_obj.status is True:
                         default_repo.update({'db_obj': db_obj})

--- a/warrior/WarriorCore/testcase_driver.py
+++ b/warrior/WarriorCore/testcase_driver.py
@@ -702,7 +702,7 @@ def check_robot_wrapper_case(testcase_filepath):
     return isRobotWrapperCase
 
 
-def main(testcase_filepath, data_repository = {}, tc_context='POSITIVE',
+def main(testcase_filepath, data_repository={}, tc_context='POSITIVE',
          runtype='SEQUENTIAL_KEYWORDS', tc_parallel=False, auto_defects=False, suite=None,
          tc_onError_action=None, iter_ts_sys=None, queue=None, jiraproj=None):
 


### PR DESCRIPTION
Use the following command (in 1 line) to test
`python warrior/Warrior -datafile wftests/warrior_tests/data/rest_functional_tests/rest_verify_response_data.xml wftests/warrior_tests/testcases/rest_functional_tests/tc_rest_verify_content_response.xml wftests/warrior_tests/testcases/rest_functional_tests/tc_rest_verify_response.xml`