### PR TITLE
WAR:1725, WAR-1734(katana-apps-demo) - verify is not working properly in iterative parallel

### DIFF
--- a/warrior/Framework/ClassUtils/testdata_class.py
+++ b/warrior/Framework/ClassUtils/testdata_class.py
@@ -562,8 +562,6 @@ class TestDataIterations(object):
         cmd_loc_list = [0]
         cmd_size = 1
         for i, cmd in enumerate(cmd_list):
-            cmd_list_subs = []
-            is_iter = False
             vc_file = vc_file_list[i]
             iteration_status = self.validate_iteration_patterns(cmd, details_dict, i)
             cmd_size = 1 if cmd_size < 1 else cmd_size
@@ -587,18 +585,10 @@ class TestDataIterations(object):
                 # move on to the next command
                 # This also means that the command parameters do not have any
                 # iteration patterns because the validation was already done.
-                if isinstance(cmd, str) and '+' not in cmd:
-                    # check if list exists in cmd
-                    td_obj = TestData()
-                    cmd_list_subs = td_obj.\
-                        list_substitution_precheck(vc_file_list[i],
-                                                   details_dict, '${', '}')
-                    if cmd_list_subs[0][i] != False:
-                        is_iter = True
-                if cmd_iter_pattern != "" or is_iter is True:
-                    # if cmd_iterpattern is not "" or if the command has a
-                    # list value, call the expand cmd_params method to resolve
-                    # the iteration patterns in the command and get a updated
+                if cmd_iter_pattern != "":
+                    # if cmd_iterpattern is not ""
+                    # call the expand cmd_params method to resolve the
+                    # iteration patterns in the command and get a updated
                     # details_dict get a updated details dict
 
                     if repeat_list[i] is not None:
@@ -678,74 +668,58 @@ class TestDataIterations(object):
         excl_list = ["command_list"]
         # First expand the iteration pattern in the actual command
         cmd_list = details_dict["command_list"]
-        vc_file_list = details_dict["vc_file_list"]
         cmd = cmd_list[index]
         # Change the repeat_list value in this index as None since td 'repeat'
         # tag is not supported for the commands with iteration pattern
         details_dict["repeat_list"][index] = None
         error = False
-        if cmd_iter_pattern != "":
-            # If details_dict["command_list"][index] has a '+', then
-            # cmd_iter_pattern will not be ""
-            resolved_cmd_list, status = self._expand_iter_pattern\
-                (cmd, cmd_iter_pattern, vc_file)
-            if status and len(resolved_cmd_list) > 0:
-                # if resolving the iteration patterns in the command
-                # was successful then replace the command in the original
-                # command list with the new commands in the resolved_cmd_list
-                cmd_list[index:index+1] = resolved_cmd_list
+        resolved_cmd_list, status = self._expand_iter_pattern\
+        (cmd, cmd_iter_pattern, vc_file)
+        if status and len(resolved_cmd_list) > 0:
+            # if resolving the iteration patterns in the command
+            # was successful then replace the command in the original
+            # command list with the new commands in the resolved_cmd_list
+            cmd_list[index:index+1] = resolved_cmd_list
 
-                # remember the length of the resolved cmd list say n
-                # for other command parameters if the iter pattern is provided
-                # resolve the iteration pattern provided, else repeat the parameter
-                # in its list by n times, so that each command that was resolved
-                # has the corresponding parameter repeated.
-                ref_length = len(resolved_cmd_list)
-                for param, _ in CMD_PARAMS.items():
-                    if param not in excl_list:
-                        param_list = details_dict[param]
-                        param_value = param_list[index]
-                        iter_pattern = self.get_iteration_pattern(param_value)\
-                            if isinstance(param_value, str) else ""
+            # remember the length of the resolved cmd list say n
+            # for other command parameters if the iter pattern is provided
+            # resolve the iteration pattern provided, else repeat the parameter
+            # in its list by n times, so that each command that was resolved
+            # has the corresponding parameter repeated.
+            ref_length = len(resolved_cmd_list)
+            for param, _ in CMD_PARAMS.items():
+                if param not in excl_list:
+                    param_list = details_dict[param]
+                    param_value = param_list[index]
+                    iter_pattern = self.get_iteration_pattern(param_value)\
+                    if isinstance(param_value, str) else ""
 
-                        if iter_pattern is not "":
-                            res_list, status = self._expand_iter_pattern\
-                                (param_value, iter_pattern, vc_file)
-                            if status and len(res_list) > 0:
-                                param_list[index:index+1] = res_list
-                            else:
-                                error = True
-                        else:
-                            res_list = []
-                            for _ in range(0, ref_length):
-                                if isinstance(param_value, list):
-                                    new_list = []
-                                    for element in param_value:
-                                        new_list.append(element)
-                                    res_list.append(new_list)
-                                else:
-                                    res_list.append(param_value)
+                    if iter_pattern is not "":
+                        res_list, status = self._expand_iter_pattern\
+                        (param_value, iter_pattern, vc_file)
+                        if status and len(res_list) > 0:
                             param_list[index:index+1] = res_list
-            else:
-                error = True
-            if error:
-                # if there were any problems in resolving the iteration patterns
-                # or if none of the nodes in the iterpattern are available in the
-                # varconfig file, i.e. resolved_cmd_list=[]mark command as False,
-                # do not care to resolve other cmd parameters. return details dict
-                cmd_list[index] = False
+                        else:
+                            error = True
+                    else:
+                        res_list = []
+                        for _ in range(0, ref_length):
+                            if isinstance(param_value, list):
+                                new_list = []
+                                for element in param_value:
+                                    new_list.append(element)
+                                res_list.append(new_list)
+                            else:
+                                res_list.append(param_value)
+                        param_list[index:index+1] = res_list
         else:
-            # if details_dict["command_list"][index] has a list value in it, then
-            # else block is executed
-            t_obj = TestData()
-            t_obj.list_substitution_precheck(vc_file_list[index],
-                                             details_dict, '${', '}')
-            cmd_value = t_obj.cmd_sub(details_dict, index, vc_file_list[index],
-                                      '${', '}')
-            if cmd_value[0] is not False:
-                t_obj.align_cmd(details_dict, index, cmd_value)
-                for param in CMD_PARAMS.keys():
-                    del details_dict[param][index]
+            error = True
+        if error:
+            # if there were any problems in resolving the iteration patterns
+            # or if none of the nodes in the iterpattern are availabel in the
+            # varconfig file, i.e. resolved_cmd_list=[]mark command as False,
+            # do not care to resolve other cmd parameters. return details dict
+            cmd_list[index] = False
         return details_dict
 
     def expand_vfy_params(self, details_dict, index, vc_file,

--- a/warrior/Framework/Utils/data_Utils.py
+++ b/warrior/Framework/Utils/data_Utils.py
@@ -15,6 +15,7 @@ from __future__ import division
 import os
 import re
 import ast
+import copy
 import operator as op
 from collections import OrderedDict
 
@@ -431,8 +432,9 @@ def get_command_details_from_testdata(testdatafile, varconfigfile=None, **attr):
 
             # Update 'cmd_loc_list' based on list substitution, this is
             # required for per_td_block iteration
-            for i in range(len(cmd_loc_list)-2):
-                for j in range(cmd_loc_list[i], cmd_loc_list[i+1]):
+            ref_cmd_loc_list = copy.deepcopy(cmd_loc_list)
+            for i in range(len(cmd_loc_list)-1):
+                for j in range(ref_cmd_loc_list[i], ref_cmd_loc_list[i+1]):
                     if cmd_list_substituted[j]:
                         pos = i+1
                         for _ in range(len(cmd_loc_list[i+1:])):

--- a/warrior/Framework/Utils/data_Utils.py
+++ b/warrior/Framework/Utils/data_Utils.py
@@ -420,13 +420,6 @@ def get_command_details_from_testdata(testdatafile, varconfigfile=None, **attr):
 
             td_iter_obj = TestDataIterations()
             details_dict, cmd_loc_list = td_iter_obj.resolve_iteration_patterns(details_dict)
-            iter_type = testdata.get('iter_type', None)
-            # Type-2 iteration - per_td_block
-            if iter_type == "per_td_block":
-                details_dict, cmd_loc_list = td_iter_obj.repeat_per_td_block(
-                                                details_dict, cmd_loc_list)
-                details_dict = td_iter_obj.arrange_per_td_block(details_dict,
-                                                                cmd_loc_list)
 
             # List substitution happens after iteration because
             # list sub cannot recognize the + sign in iteration
@@ -435,6 +428,24 @@ def get_command_details_from_testdata(testdatafile, varconfigfile=None, **attr):
                                                                 start_pat, end_pat)
             td_obj.list_substitution(details_dict, varconfigfile, cmd_list_substituted,
                                      verify_text_substituted, start_pat, end_pat)
+
+            # Update 'cmd_loc_list' based on list substitution, this is
+            # required for per_td_block iteration
+            for i in range(len(cmd_loc_list)-2):
+                for j in range(cmd_loc_list[i], cmd_loc_list[i+1]):
+                    if cmd_list_substituted[j]:
+                        pos = i+1
+                        for _ in range(len(cmd_loc_list[i+1:])):
+                            cmd_loc_list[pos] = cmd_loc_list[pos] + cmd_list_substituted[j] - 1
+                            pos += 1
+
+            iter_type = testdata.get('iter_type', None)
+            # Type-2 iteration - per_td_block
+            if iter_type == "per_td_block":
+                details_dict, cmd_loc_list = td_iter_obj.repeat_per_td_block(
+                                                details_dict, cmd_loc_list)
+                details_dict = td_iter_obj.arrange_per_td_block(details_dict,
+                                                                cmd_loc_list)
 
             details_dict = td_obj.varsub_varconfig_substitutions(
                             details_dict, vc_file=varconfigfile, var_sub=None,


### PR DESCRIPTION
PR for develop branch : #375 

This issue(WAR-1725) not just happens for iterative parallel execution, it happens in all cases when the list iteration is used. Both WAR-1725 and WAR-1734 were working well till 3.6.0 and were introduced by #313 in 3.7.0.

Solution:
1. Took out the fix given in #313(WAR-1445)
2. Given new fix for WAR-1445

Fix explanation:
We use location/index to rearrange the command_list that was iterated using '+' for per_td_block(with yes) iteration. Here I have added a similar logic for list iteration so that the commands derived from list will be treated same like the commands derived using '+'.

Note: WAR-1734 is also resolved since the PR which introduced it, is completely removed here.

Regression logs and tests instructions are in WAR-1725