### PR TITLE
WAR-1674(katana-apps-demo): Unable to check api_response with regex pattern using verify_response keyword 

### DIFF
--- a/warrior/Actions/RestActions/rest_actions.py
+++ b/warrior/Actions/RestActions/rest_actions.py
@@ -2993,8 +2993,9 @@ class RestActions(object):
                 3. expected_api_response: expected api response given by
                    the user.
 
-                    pattern: can be string or file name and response can be
-                    simple text or xml or json
+                    pattern: can be string or file name(expected string will be
+                    treated as python regular expression during match)
+                    and response can be simple text or xml or json
                     Multiple Values: No
                     Max Number of values accepted: 1
 

--- a/warrior/Actions/RestActions/rest_actions.py
+++ b/warrior/Actions/RestActions/rest_actions.py
@@ -3000,8 +3000,13 @@ class RestActions(object):
                     Max Number of values accepted: 1
 
                 4. expected_response_type: The type of expected response
-                    Can be xml or json or text
-                
+                    Can be xml or json or text. Expected response values
+                    will be treated as python regular expressions for
+                    jsonpath/xpath comparison_modes and will be searched
+                    in the actual api response. Use 'regex=expression' as
+                    comparison_mode to support python regular expression
+                    for string response.
+
                 5. comparison_mode:
                    This is the mode in which you wish to compare
                    The supported comparison modes are

--- a/warrior/Actions/RestActions/rest_actions.py
+++ b/warrior/Actions/RestActions/rest_actions.py
@@ -3005,7 +3005,7 @@ class RestActions(object):
                     jsonpath/xpath comparison_modes and will be searched
                     in the actual api response. Use 'regex=expression' as
                     comparison_mode to support python regular expression
-                    for string response.
+                    for text response.
 
                 5. comparison_mode:
                    This is the mode in which you wish to compare

--- a/warrior/Actions/RestActions/rest_actions.py
+++ b/warrior/Actions/RestActions/rest_actions.py
@@ -2993,19 +2993,21 @@ class RestActions(object):
                 3. expected_api_response: expected api response given by
                    the user.
 
-                    pattern: can be string or file name(expected string will be
-                    treated as python regular expression during match)
-                    and response can be simple text or xml or json
+                    pattern: can be string or file name and response can be
+                    simple text or xml or json
                     Multiple Values: No
                     Max Number of values accepted: 1
 
                 4. expected_response_type: The type of expected response
-                    Can be xml or json or text. Expected response values
-                    will be treated as python regular expressions for
-                    jsonpath/xpath comparison_modes and will be searched
-                    in the actual api response. Use 'regex=expression' as
-                    comparison_mode to support python regular expression
-                    for text response.
+                    Can be xml or json or text
+                    For jsonpath & xpath comparison_modes, verify status will
+                    be marked as pass if anyone the below operations is successful:
+                        1. Equality match: Check if the expected response is
+                        equal to API response
+                        2. Regex search: Check if the expected
+                        response(pattern) is in API response
+                    Use 'regex=expression' as comparison_mode to support
+                    python regular expression for text response.
 
                 5. comparison_mode:
                    This is the mode in which you wish to compare

--- a/warrior/Framework/ClassUtils/json_utils_class.py
+++ b/warrior/Framework/ClassUtils/json_utils_class.py
@@ -255,9 +255,11 @@ class JsonUtils(object):
         for index, jsonpath in enumerate(list_of_jsonpath):
             json_path = jsonpath.strip("jsonpath=")
             value = self.get_value_for_nested_key(json_response, json_path)
-            # Check if the expected value/pattern is in actual response
-            match = re.search(list_of_expected_api_responses[index], value)
-            if not match:
+            # Equality match: Check if the expected response is equal to API response
+            eq_match = True if value == list_of_expected_api_responses[index] else False
+            # Regex search: Check if the expected response pattern is in API response
+            regex_match = re.search(list_of_expected_api_responses[index], value)
+            if not(eq_match or regex_match):
                 status = False
                 print_error("For the given {0} the expected response value is"
                             " {1} but the actual response"

--- a/warrior/Framework/ClassUtils/json_utils_class.py
+++ b/warrior/Framework/ClassUtils/json_utils_class.py
@@ -252,7 +252,7 @@ class JsonUtils(object):
         status = True
         json_response = json.loads(response)
         for index, jsonpath in enumerate(list_of_jsonpath):
-            json_path = jsonpath.strip("json=")
+            json_path = jsonpath.strip("jsonpath=")
             value = self.get_value_for_nested_key(json_response, json_path)
             if value != list_of_expected_api_responses[index]:
                 status = False

--- a/warrior/Framework/ClassUtils/json_utils_class.py
+++ b/warrior/Framework/ClassUtils/json_utils_class.py
@@ -14,7 +14,7 @@ limitations under the License.
 """API for json related operations """
 import json
 import re
-from Framework.Utils.print_Utils import print_info, print_exception, print_error
+from Framework.Utils.print_Utils import print_info, print_exception, print_error, print_warning
 from Framework.Utils.testcase_Utils import pNote,pSubStep
 import difflib
 
@@ -255,16 +255,23 @@ class JsonUtils(object):
         for index, jsonpath in enumerate(list_of_jsonpath):
             json_path = jsonpath.strip("jsonpath=")
             value = self.get_value_for_nested_key(json_response, json_path)
-            # Equality match: Check if the expected response is equal to API response
-            eq_match = True if value == list_of_expected_api_responses[index] else False
-            # Regex search: Check if the expected response pattern is in API response
-            regex_match = re.search(list_of_expected_api_responses[index], value)
-            if not(eq_match or regex_match):
+            # Equality_match: Check if the expected response is equal to API response
+            match = True if value == list_of_expected_api_responses[index] else False
+            # Perform Regex_search if equality match fails
+            if match is False:
+                try:
+                    # Regex_search: Check if the expected response pattern is in API response
+                    match = re.search(list_of_expected_api_responses[index], value)
+                except Exception:
+                    print_warning("Python regex search failed, invalid "
+                                  "expected_response_pattern '{}' is "
+                                  "provided".format(list_of_expected_api_responses[index]))
+            if not match:
                 status = False
-                print_error("For the given {0} the expected response value is"
-                            " {1} but the actual response"
-                            " value is {2}".format(jsonpath,
-                            list_of_expected_api_responses[index], value))
+                print_error("For the given '{0}' the expected response value is '{1}'. "
+                            "It doesn't match or available in the actual response value "
+                            "'{2}'".format(jsonpath, list_of_expected_api_responses[index],
+                                           value))
         return status
 
     def get_value_for_nested_key(self, json_response, json_path):

--- a/warrior/Framework/ClassUtils/json_utils_class.py
+++ b/warrior/Framework/ClassUtils/json_utils_class.py
@@ -13,6 +13,7 @@ limitations under the License.
 
 """API for json related operations """
 import json
+import re
 from Framework.Utils.print_Utils import print_info, print_exception, print_error
 from Framework.Utils.testcase_Utils import pNote,pSubStep
 import difflib
@@ -254,14 +255,16 @@ class JsonUtils(object):
         for index, jsonpath in enumerate(list_of_jsonpath):
             json_path = jsonpath.strip("jsonpath=")
             value = self.get_value_for_nested_key(json_response, json_path)
-            if value != list_of_expected_api_responses[index]:
+            # Check if the expected value/pattern is in actual response
+            match = re.search(list_of_expected_api_responses[index], value)
+            if not match:
                 status = False
                 print_error("For the given {0} the expected response value is"
                             " {1} but the actual response"
                             " value is {2}".format(jsonpath,
                             list_of_expected_api_responses[index], value))
         return status
-    
+
     def get_value_for_nested_key(self, json_response, json_path):
         """
             Returns the value of the nested key in the dictionary

--- a/warrior/Framework/Utils/xml_Utils.py
+++ b/warrior/Framework/Utils/xml_Utils.py
@@ -986,9 +986,11 @@ def compare_xml_using_xpath(response, list_of_xpath, list_of_expected_api_respon
         for index, xpath_pattern in enumerate(list_of_xpath):
             xpath = xpath_pattern.strip("xpath=")
             value = getValuebyTagFromStringWithXpath(response, xpath, None)
-            # Check if the expected value/pattern is in actual response
-            match = re.search(list_of_expected_api_responses[index], value)
-            if not match:
+            # Equality match: Check if the expected response is equal to API response
+            eq_match = True if value == list_of_expected_api_responses[index] else False
+            # Regex search: Check if the expected response pattern is in API response
+            regex_match = re.search(list_of_expected_api_responses[index], value)
+            if not(eq_match or regex_match):
                 status = False
                 print_error("For the given {0} the expected response value is"
                             " {1} but the actual response"

--- a/warrior/Framework/Utils/xml_Utils.py
+++ b/warrior/Framework/Utils/xml_Utils.py
@@ -15,7 +15,7 @@ import json
 import sys
 import difflib
 import os
-
+import re
 import file_Utils
 import os.path
 
@@ -986,7 +986,9 @@ def compare_xml_using_xpath(response, list_of_xpath, list_of_expected_api_respon
         for index, xpath_pattern in enumerate(list_of_xpath):
             xpath = xpath_pattern.strip("xpath=")
             value = getValuebyTagFromStringWithXpath(response, xpath, None)
-            if value != list_of_expected_api_responses[index]:
+            # Check if the expected value/pattern is in actual response
+            match = re.search(list_of_expected_api_responses[index], value)
+            if not match:
                 status = False
                 print_error("For the given {0} the expected response value is"
                             " {1} but the actual response"

--- a/warrior/Framework/Utils/xml_Utils.py
+++ b/warrior/Framework/Utils/xml_Utils.py
@@ -986,16 +986,23 @@ def compare_xml_using_xpath(response, list_of_xpath, list_of_expected_api_respon
         for index, xpath_pattern in enumerate(list_of_xpath):
             xpath = xpath_pattern.strip("xpath=")
             value = getValuebyTagFromStringWithXpath(response, xpath, None)
-            # Equality match: Check if the expected response is equal to API response
-            eq_match = True if value == list_of_expected_api_responses[index] else False
-            # Regex search: Check if the expected response pattern is in API response
-            regex_match = re.search(list_of_expected_api_responses[index], value)
-            if not(eq_match or regex_match):
+            # Equality_match: Check if the expected response is equal to API response
+            match = True if value == list_of_expected_api_responses[index] else False
+            # Perform Regex_search if equality match fails
+            if match is False:
+                try:
+                    # Regex_search: Check if the expected response pattern is in API response
+                    match = re.search(list_of_expected_api_responses[index], value)
+                except Exception:
+                    print_warning("Python regex search failed, invalid "
+                                  "expected_response_pattern '{}' is "
+                                  "provided".format(list_of_expected_api_responses[index]))
+            if not match:
                 status = False
-                print_error("For the given {0} the expected response value is"
-                            " {1} but the actual response"
-                            " value is {2}".format(xpath_pattern,
-                            list_of_expected_api_responses[index], value))
+                print_error("For the given '{0}' the expected response value is '{1}'. "
+                            "It doesn't match or available in the actual response value "
+                            "'{2}'".format(xpath_pattern, list_of_expected_api_responses[index],
+                                           value))
     return status
 
 def list_path_responses_datafile(datafile, system_name):

--- a/wftests/warrior_tests/suites/rest_functional_tests/rest_json_test_Suite.xml
+++ b/wftests/warrior_tests/suites/rest_functional_tests/rest_json_test_Suite.xml
@@ -33,6 +33,12 @@
 			<onError action="next"/>
 			<impact>impact</impact>
 		</Testcase>
-		
+		<Testcase>
+			<path>../../testcases/rest_functional_tests/tc_rest_verify_content_response.xml</path>
+			<context>positive</context>
+			<runtype>sequential_keywords</runtype>
+			<onError action="next"/>
+			<impact>impact</impact>
+		</Testcase>
 	</Testcases>
 </TestSuite>

--- a/wftests/warrior_tests/testcases/rest_functional_tests/tc_rest_verify_content_response.xml
+++ b/wftests/warrior_tests/testcases/rest_functional_tests/tc_rest_verify_content_response.xml
@@ -108,5 +108,43 @@
 			<context>positive</context>
 			<impact>impact</impact>
 		</step>
+		<step Driver="rest_driver" Keyword="perform_http_get" TS="7">
+			<Arguments>
+				<argument name="system_name" value="http_bin_1"/>
+				<argument name="url" value="http://httpbin.org/response-headers?key=5"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step tests the GET capability of REST</Description>
+			<Execute ExecType="Yes"/>
+			<context>positive</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="verify_response" TS="8">
+			<Arguments>
+				<argument name="system_name" value="http_bin_1"/>
+				<argument name="expected_api_response" value="[4-7]"/>
+				<argument name="expected_response_type" value="json"/>
+				<argument name="comparison_mode" value="jsonpath=key"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step verifies the API response with the expected API response(with python regex)</Description>
+			<Execute ExecType="Yes"/>
+			<context>positive</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="verify_response" TS="9">
+			<Arguments>
+				<argument name="system_name" value="http_bin_2"/>
+				<argument name="expected_api_response" value="Date.+of pub.*on"/>
+				<argument name="expected_response_type" value="xml"/>
+				<argument name="request_id" value="123"/>
+				<argument name="comparison_mode" value="xpath=/*/@date"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step verifies the API response with the expected API response(with python regex)</Description>
+			<Execute ExecType="Yes"/>
+			<context>positive</context>
+			<impact>impact</impact>
+		</step>
 	</Steps>
 </Testcase>

--- a/wftests/warrior_tests/testcases/rest_functional_tests/tc_rest_verify_content_response.xml
+++ b/wftests/warrior_tests/testcases/rest_functional_tests/tc_rest_verify_content_response.xml
@@ -68,7 +68,7 @@
 			<context>positive</context>
 			<impact>impact</impact>
 		</step>
-		<step Driver="rest_driver" Keyword="verify_response" TS="4">
+		<step Driver="rest_driver" Keyword="verify_response" TS="5">
 			<Arguments>
 				<argument name="system_name" value="http_bin_2"/>
 				<argument name="expected_api_response" value="Date of publication"/>
@@ -82,7 +82,7 @@
 			<context>positive</context>
 			<impact>impact</impact>
 		</step>
-		<step Driver="rest_driver" Keyword="perform_http_get" TS="5">
+		<step Driver="rest_driver" Keyword="perform_http_get" TS="6">
 			<Arguments>
 				<argument name="system_name" value="http_bin_3"/>
 				<argument name="url" value="http://httpbin.org/robots.txt"/>
@@ -94,7 +94,7 @@
 			<context>positive</context>
 			<impact>impact</impact>
 		</step>
-		<step Driver="rest_driver" Keyword="verify_response" TS="6">
+		<step Driver="rest_driver" Keyword="verify_response" TS="7">
 			<Arguments>
 				<argument name="system_name" value="http_bin_3"/>
 				<argument name="expected_api_response" value=""/>
@@ -108,10 +108,10 @@
 			<context>positive</context>
 			<impact>impact</impact>
 		</step>
-		<step Driver="rest_driver" Keyword="perform_http_get" TS="7">
+		<step Driver="rest_driver" Keyword="perform_http_get" TS="8">
 			<Arguments>
 				<argument name="system_name" value="http_bin_1"/>
-				<argument name="url" value="http://httpbin.org/response-headers?key=5"/>
+				<argument name="url" value="http://httpbin.org/response-headers?key1=5&amp;key2=[1.2"/>
 			</Arguments>
 			<onError action="next"/>
 			<Description>This step tests the GET capability of REST</Description>
@@ -119,20 +119,59 @@
 			<context>positive</context>
 			<impact>impact</impact>
 		</step>
-		<step Driver="rest_driver" Keyword="verify_response" TS="8">
+		<step Driver="rest_driver" Keyword="verify_response" TS="9">
 			<Arguments>
 				<argument name="system_name" value="http_bin_1"/>
 				<argument name="expected_api_response" value="[4-7]"/>
 				<argument name="expected_response_type" value="json"/>
-				<argument name="comparison_mode" value="jsonpath=key"/>
+				<argument name="comparison_mode" value="jsonpath=key1"/>
 			</Arguments>
 			<onError action="next"/>
-			<Description>This step verifies the API response with the expected API response(with python regex)</Description>
+			<Description>This step verifies the API response with the expected API response(Regex search - Pass)</Description>
 			<Execute ExecType="Yes"/>
 			<context>positive</context>
 			<impact>impact</impact>
 		</step>
-		<step Driver="rest_driver" Keyword="verify_response" TS="9">
+		<step Driver="rest_driver" Keyword="verify_response" TS="10">
+			<Arguments>
+				<argument name="system_name" value="http_bin_1"/>
+				<argument name="expected_api_response" value="[6-10]"/>
+				<argument name="expected_response_type" value="json"/>
+				<argument name="comparison_mode" value="jsonpath=key1"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step verifies the API response with the expected API response(Regex search - Fail)</Description>
+			<Execute ExecType="Yes"/>
+			<context>negative</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="verify_response" TS="11">
+			<Arguments>
+				<argument name="system_name" value="http_bin_1"/>
+				<argument name="expected_api_response" value="[1.2"/>
+				<argument name="expected_response_type" value="json"/>
+				<argument name="comparison_mode" value="jsonpath=key2"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step verifies the API response with the expected API response(Equality check with special chars - Pass)</Description>
+			<Execute ExecType="Yes"/>
+			<context>positive</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="verify_response" TS="12">
+			<Arguments>
+				<argument name="system_name" value="http_bin_1"/>
+				<argument name="expected_api_response" value="[1."/>
+				<argument name="expected_response_type" value="json"/>
+				<argument name="comparison_mode" value="jsonpath=key2"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step verifies the API response with the expected API response(Equality check with special chars - Fail)</Description>
+			<Execute ExecType="Yes"/>
+			<context>negative</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="verify_response" TS="13">
 			<Arguments>
 				<argument name="system_name" value="http_bin_2"/>
 				<argument name="expected_api_response" value="Date.+of pub.*on"/>
@@ -141,9 +180,23 @@
 				<argument name="comparison_mode" value="xpath=/*/@date"/>
 			</Arguments>
 			<onError action="next"/>
-			<Description>This step verifies the API response with the expected API response(with python regex)</Description>
+			<Description>This step verifies the API response with the expected API response(Regex search - Pass)</Description>
 			<Execute ExecType="Yes"/>
 			<context>positive</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="verify_response" TS="14">
+			<Arguments>
+				<argument name="system_name" value="http_bin_2"/>
+				<argument name="expected_api_response" value="Date.+of pub.?on"/>
+				<argument name="expected_response_type" value="xml"/>
+				<argument name="request_id" value="123"/>
+				<argument name="comparison_mode" value="xpath=/*/@date"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step verifies the API response with the expected API response(Regex search - Fail)</Description>
+			<Execute ExecType="Yes"/>
+			<context>negative</context>
 			<impact>impact</impact>
 		</step>
 	</Steps>


### PR DESCRIPTION
PR for develop branch : #381 

Code changes:

1. Add regex verification support for jsonpath/xmlpath' comparison modes in 'verify_response' rest kw
2. Fix a bug in jsonpath comparison mode verification(more details in WAR-1674)

Execute 'wftests/warrior_tests/testcases/rest_functional_tests/tc_rest_verify_content_response.xml' to verify the fix. Regression logs are in WAR-1674.