### PR TITLE
WAR-1683(develop): NETCONF get function is not working with xpath

### DIFF
--- a/warrior/Framework/ClassUtils/netconf.py
+++ b/warrior/Framework/ClassUtils/netconf.py
@@ -544,7 +544,10 @@ class client(Thread):
             if filter_type == "subtree":
                 xml += "<filter type='subtree'>%s</filter>" % filter_string
             elif filter_type == "xpath":
-                xml += "<filter type='xpath' select='%s'/>" % filter_string
+                if "'" in filter_string:
+                    xml += "<filter type='xpath' select=\"%s\"/>" % filter_string
+                else:
+                    xml += "<filter type='xpath' select='%s'/>" % filter_string
             else:
                 xml += "%s" %filter_string
         xml += "</get>"


### PR DESCRIPTION
Issue description:
User provides xpath 'filter_string' value in testcase as an argument for netconf keywords. It can have a single or double quotes in it, there are two ways to represent it in xml(tc):

1. If xpath filter_string has single quotes in it then it has be wrapped inside double quotes
`Ex. <argument name="filter_string" value="/snmp/trap-group[contains(trap-group-name,'testing1')]"/>`

2. If xpath filter_string has double quotes in it then it has be wrapped inside single quotes
`Ex. <argument name="filter_string" value='/snmp/trap-group[contains(trap-group-name,"testing1")]'/>`

Warrior constructs XML request_string(to be sent to netconf interface) using filter_type and filter_string values in 'netconf.py: get' util method. Since the incoming filter_string can have single or double quotes, we have to use the one which is not in the filter_string while defining it in python string format.

We had already handled this in 'get_config' & 'create_subscription' methods but 'get' method can only handle 'filter_string' with double quotes.
If single quotes is used, it will create a malformed xml and will throw 'ExpatError: not well-formed (invalid token)' error.

Fix: Update 'netconf.py: get' method to handle xpath 'filter_string' with single quotes in it.

Tested the use-case provided by the reporter, logs are in Jira ticket.