### PR TITLE
WAR-1717:Need snapshot of Result Summary within the mail

### DIFF
--- a/warrior/Framework/Utils/email_utils.py
+++ b/warrior/Framework/Utils/email_utils.py
@@ -136,15 +136,15 @@ def construct_mail_body(exec_type, abs_filepath, logs_dir, results_dir):
     # complete html body that will be sent through mail
     if exec_type == 'Project: ':
         for proj in project_sum:
-            project = project + ('<tr><td>{0}</td><td>{1}</td><td>{2}</td><td>{3}</td></tr>'
+            project = project + ('<tr><td>{0}</td><td>{1}</td><td>{2}</td><td>{3}</td></tr>\n'
                                  .format(proj[0], proj[1], proj[2], proj[3]))
         for value in suite_tc_sum:
-            suite_tc = suite_tc + ('<tr><td>{0}</td><td>{1}</td><td>{2}</td><td>{3}</td></tr>'
+            suite_tc = suite_tc + ('<tr><td>{0}</td><td>{1}</td><td>{2}</td><td>{3}</td></tr>\n'
                                    .format(value[0], value[1], value[2], value[3]))
         body = body_arg + project + suite_tc + "</table></body></html>"
     elif exec_type == 'Test Suite: ' or exec_type == 'Test Case: ':
         for value in suite_tc_sum:
-            suite_tc = suite_tc + ('<tr><td>{0}</td><td>{1}</td><td>{2}</td><td>{3}</td></tr>'
+            suite_tc = suite_tc + ('<tr><td>{0}</td><td>{1}</td><td>{2}</td><td>{3}</td></tr>\n'
                                    .format(value[0], value[1], value[2], value[3]))
         body = body_arg + suite_tc + "</table></body></html>"
     return body

--- a/warrior/Framework/Utils/email_utils.py
+++ b/warrior/Framework/Utils/email_utils.py
@@ -119,12 +119,12 @@ def construct_mail_body(exec_type, abs_filepath, logs_dir, results_dir):
     :Returns:
         1. body - return mail body
     """
-    junit_result_file = results_dir + os.sep + \
-        file_Utils.getNameOnly(file_Utils.getFileName(abs_filepath)) + "_junit.xml"
+    junit_result_file = os.path.join(
+        results_dir, file_Utils.getNameOnly(file_Utils.getFileName(abs_filepath))) + "_junit.xml"
     junit_object = ExecutionSummary(junit_result_file)
     project_sum = junit_object.project_summary(junit_result_file)
     suite_tc_sum = junit_object.suite_summary(junit_result_file)
-    suite_tc, project = "", ""
+    suite_tc, body = "", ""
     body_arg = ('<html><body><p><b>{0}</b>{1}</p>'
                 '<p><b>Logs directory:</b>{2}</p>'
                 '<p><b>Results directory:</b>{3}</p>'
@@ -135,6 +135,7 @@ def construct_mail_body(exec_type, abs_filepath, logs_dir, results_dir):
                                                     logs_dir, results_dir)
     # complete html body that will be sent through mail
     if exec_type == 'Project: ':
+        project = ""
         for proj in project_sum:
             project = project + ('<tr><td>{0}</td><td>{1}</td><td>{2}</td><td>{3}</td></tr>\n'
                                  .format(proj[0], proj[1], proj[2], proj[3]))
@@ -207,7 +208,7 @@ def send_email(smtp_host, sender, receivers, subject, body, files):
     receivers_list = [receiver.strip() for receiver in receivers.split(',')]
     message['Subject'] = subject
 
-    # For formatting the execution summary in mail body, changed plain text to html
+    # HTML is used for better formatting of mail body
     part = MIMEText(body, 'html')
     message.attach(part)
 

--- a/warrior/Framework/Utils/email_utils.py
+++ b/warrior/Framework/Utils/email_utils.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-#Utility to send email using smtp
+# Utility to send email using smtp
 # Import smtplib for the actual sending function
 
 import smtplib
@@ -25,6 +25,7 @@ import Tools
 from Framework.Utils.print_Utils import print_debug
 from Framework.Utils import file_Utils
 from Framework.Utils.testcase_Utils import pNote
+from WarriorCore.Classes.execution_summary_class import ExecutionSummary
 
 
 def set_params_send_email(addsubject, data_repository, files, mail_on):
@@ -108,6 +109,47 @@ def get_email_params(mail_on='per_execution'):
     return smtp_host, sender, receivers, subject
 
 
+def construct_mail_body(exec_type, abs_filepath, logs_dir, results_dir):
+    """ construct e-mail body with Project, Logs/Results directory & Execution summary
+    :Arguments:
+        1. exec_type - type of test(case/suite/project)
+        2. abs_filepath - full path of case/suite/project
+        3. logs_dir - full path of logs directory
+        4. results_dir - full path of results directory
+    :Returns:
+        1. body - return mail body
+    """
+    junit_result_file = results_dir + os.sep + \
+        file_Utils.getNameOnly(file_Utils.getFileName(abs_filepath)) + "_junit.xml"
+    junit_object = ExecutionSummary(junit_result_file)
+    project_sum = junit_object.project_summary(junit_result_file)
+    suite_tc_sum = junit_object.suite_summary(junit_result_file)
+    suite_tc, project = "", ""
+    body_arg = ('<html><body><p><b>{0}</b>{1}</p>'
+                '<p><b>Logs directory:</b>{2}</p>'
+                '<p><b>Results directory:</b>{3}</p>'
+                '<p><b>Execution Summary:</b></p>'
+                '<table cellspacing="10" cellpadding="0"><tr><td><b>Type</b>'
+                '</td><td><b>Name</b></td><td><b>Status</b></td>'
+                '<td><b>Path</b></td></tr>').format(exec_type, abs_filepath,
+                                                    logs_dir, results_dir)
+    # complete html body that will be sent through mail
+    if exec_type == 'Project: ':
+        for proj in project_sum:
+            project = project + ('<tr><td>{0}</td><td>{1}</td><td>{2}</td><td>{3}</td></tr>'
+                                 .format(proj[0], proj[1], proj[2], proj[3]))
+        for value in suite_tc_sum:
+            suite_tc = suite_tc + ('<tr><td>{0}</td><td>{1}</td><td>{2}</td><td>{3}</td></tr>'
+                                   .format(value[0], value[1], value[2], value[3]))
+        body = body_arg + project + suite_tc + "</table></body></html>"
+    elif exec_type == 'Test Suite: ' or exec_type == 'Test Case: ':
+        for value in suite_tc_sum:
+            suite_tc = suite_tc + ('<tr><td>{0}</td><td>{1}</td><td>{2}</td><td>{3}</td></tr>'
+                                   .format(value[0], value[1], value[2], value[3]))
+        body = body_arg + suite_tc + "</table></body></html>"
+    return body
+
+
 def compose_send_email(exec_type, abs_filepath, logs_dir, results_dir, result,
                        mail_on="per_execution"):
     """ compose and sends email from smtp server using input arguments as:
@@ -126,8 +168,7 @@ def compose_send_email(exec_type, abs_filepath, logs_dir, results_dir, result,
     resultconverted = {"True": "Pass", "False": "Fail", "ERROR": "Error",
                        "EXCEPTION": "Exception"}.get(str(result))
     subject = str(resultconverted)+": "+file_Utils.getFileName(abs_filepath)
-    body = [exec_type+abs_filepath, "Logs directory: "+logs_dir,
-            "Results directory: "+results_dir]
+    body = construct_mail_body(exec_type, abs_filepath, logs_dir, results_dir)
     report_attachment = results_dir + os.sep + \
         file_Utils.getNameOnly(file_Utils.getFileName(abs_filepath)) + ".html"
 
@@ -166,7 +207,8 @@ def send_email(smtp_host, sender, receivers, subject, body, files):
     receivers_list = [receiver.strip() for receiver in receivers.split(',')]
     message['Subject'] = subject
 
-    part = MIMEText(body, 'plain')
+    # For formatting the execution summary in mail body, changed plain text to html
+    part = MIMEText(body, 'html')
     message.attach(part)
 
     for attach_file in files or []:

--- a/warrior/WarriorCore/Classes/execution_summary_class.py
+++ b/warrior/WarriorCore/Classes/execution_summary_class.py
@@ -27,6 +27,7 @@ class ExecutionSummary():
     def project_summary(self, junit_file):
         """To get the project name, project status and it's location"""
         tree = xml_Utils.get_tree_from_file(self.junit_file)
+        project_list = []
         for names in tree.iter('testsuites'):
             proj_detail = names.attrib
             proj_name = proj_detail.get('name')
@@ -38,12 +39,13 @@ class ExecutionSummary():
                 if project_details.get('name') == 'location':
                     proj_loc.append(project_details.get('value'))
                     proj_location = proj_loc[0]
-            print_info("{0:10}{1:50}{2:10}{3:30}".format(file_type, proj_name, project_status,
-                                                         proj_location))
+            project_list.append([file_type, proj_name, project_status, proj_location])
+        return project_list
 
     def suite_summary(self, junit_file):
         """ To get the name, status and location of both test suite and test case"""
         tree = xml_Utils.get_tree_from_file(self.junit_file)
+        suite_tc_list = []
         for values in tree.iter('testsuite'):
             suite_detail = values.attrib
             suite_name = suite_detail.get('name')
@@ -51,8 +53,7 @@ class ExecutionSummary():
             suite_location = suite_detail.get('suite_location')
             suite_result_dir = suite_detail.get('resultsdir')
             if suite_location is not None:
-                print_info("{0:10}{1:50}{2:10}{3:30}".format("Suites", suite_name, suite_status,
-                                                             suite_location))
+                suite_tc_list.append(["Suites", suite_name, suite_status, suite_location])
             for value in tree.iter('testcase'):
                 testcase_details = value.attrib
                 testcase_status = testcase_details.get('status')
@@ -63,9 +64,10 @@ class ExecutionSummary():
                     case_result_dir = os.path.dirname(case_result_dir_with_tc_name)
                     # suite junit element will not have resultsdir attrib for case execution
                     if suite_result_dir is None or suite_result_dir == case_result_dir:
-                        print_info("{0:10}{1:50}{2:10}{3:30}".format("Testcase", testcase_name,
-                                                                     testcase_status,
-                                                                     testcase_location))
+                        suite_tc_list.append(["Testcase", testcase_name, testcase_status,
+                                              testcase_location])
+        # suite_tc_list appends suites and test cases as per execution order
+        return suite_tc_list
 
     def get_file_type(self, junit_file):
         """To get the file type which is given for execution"""
@@ -83,11 +85,21 @@ class ExecutionSummary():
         """To print the consolidated test cases result in console at the end of Test Case/Test
            Suite/Project Execution"""
         file_type = self.get_file_type(junit_file)
+        # Formatting execution summary as project_summary and suite_summary returns the list values
         print_info("+++++++++++++++++++++++++++++++++++++++++++++++++ Execution Summary +++++++++++++++++++++++++++++++++++++++++++++++++")
         print_info("{0:10}{1:50}{2:10}{3:50}".format('Type', 'Name', 'Status', 'Path'))
         if file_type == "Project":
-            self.project_summary(junit_file)
-            self.suite_summary(junit_file)
+            project_exec = self.project_summary(junit_file)
+            for proj in project_exec:
+                print_info(("{0:10}{1:50}{2:10}{3:30}"
+                            .format(proj[0], proj[1], proj[2], proj[3])))
+            suite_tc_exec = self.suite_summary(junit_file)
+            for suite_tc in suite_tc_exec:
+                print_info(("{0:10}{1:50}{2:10}{3:30}"
+                            .format(suite_tc[0], suite_tc[1], suite_tc[2], suite_tc[3])))
         elif file_type == "Suites":
-            self.suite_summary(junit_file)
+            suite_tc_exec = self.suite_summary(junit_file)
+            for suite_tc in suite_tc_exec:
+                print_info(("{0:10}{1:50}{2:10}{3:30}"
+                            .format(suite_tc[0], suite_tc[1], suite_tc[2], suite_tc[3])))
         print_info("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++")


### PR DESCRIPTION
Requirement : Add 'execution summary' in email sent by WF along with (i) Project/Suite/Case path , (ii) Logs directory & (iii) Result directory

Fix explanation :

Modified project_summary & suite_summary methods to return the execution summary prints(which were printed inside these methods earlier, now it will be printed in print_result_in_console method)
Added 'construct_mail_body' method to format execution summary in html format that would be added in email
Earlier the mail body was in 'plain text' format, now changed it to 'html' for better formatting of mail body
Attached the regression logs and added the instruction for testing in JIRA.