### PR TITLE
WAR-1679: In store_in_repo  keyword user was allowed to update only variable at a time, it should allow to update n number of variable

### DIFF
--- a/warrior/Actions/CommonActions/common_actions.py
+++ b/warrior/Actions/CommonActions/common_actions.py
@@ -112,7 +112,7 @@ class CommonActions(object):
         return status
 
     def store_in_repo(self, datavar=None, datavalue=None, datatype='str',
-                      filepath=None, jsonkey="repo_variables",):
+                      filepath=None, jsonkey="repo_variables"):
         """Stores datavalue in datavar of datarepository
         :Argument:
             1. datavar = Key to be used to store datavalue in data_repository,

--- a/warrior/Actions/CommonActions/common_actions.py
+++ b/warrior/Actions/CommonActions/common_actions.py
@@ -111,26 +111,41 @@ class CommonActions(object):
         Utils.testcase_Utils.report_substep_status(status)
         return status
 
-    def store_in_repo(self, datavar, datavalue, type='str'):
-        """For storing datavalue in datavar datarepository
+    def store_in_repo(self, datavar=None, datavalue=None, datatype='str',
+                      filepath=None, jsonkey="repo_variables",):
+        """Stores datavalue in datavar of datarepository
         :Argument:
-            datavar = var in data repository in which to store
-                      this could be dot separated to store in nested fashion
-                      i.e., if var is k1.k2.k3 then the data value would be
-                      stored as a value in datarepository[k1][k2][k3]
-            datavalue = the value to be stored
-            type = type of datavalue (string/int/float)
+            1. datavar = Key to be used to store datavalue in data_repository,
+                         this could be dot separated to store in nested fashion
+                            i.e., if var is k1.k2.k3 then the data value would be
+                            stored as a value in datarepository[k1][k2][k3]
+            2. datavalue = Value to be stored
+            3. datatype = Type of datavalue(string/int/float)
+            4. filepath = Json file where datarepository variables are defined.
+                          It is to store multiple key,value pairs in datarepository.
+            5. jsonkey = The key where all the REPO variables & values are
+                         defined in the filepath
+
+            Sample JSON file:
+                 {
+                     "repo_variables": {
+                         "var1": {"type": "int", "value": "10"},
+                         "var2.var3": {"value": "10"},
+                         "var4.var5": "1"
+                         }
+                 }
+            All three formats in the above sample block are allowed. If 'type'
+            is not provided, value will be converted as string by default.
         """
         def get_dict_to_update(var, val):
             """
-
-            The function creates a dictionary with Variable and value. If Variable has "." seperated
-            keys then the value is updated at appropriate level of the nested dictionary.
-            :param var: Dictionary Key or Key seperated with "." for nested dict keys.
+            The function creates a dictionary with Variable and value.
+            If Variable has "." separated keys then the value is updated at
+            appropriate level of the nested dictionary.
+            :param var: Dictionary Key or Key separated with "." for nested dict keys.
             :param val: Value for the Key.
 
             :return: Dictionary
-
             """
             dic = {}
             if '.' in var:
@@ -139,17 +154,59 @@ class CommonActions(object):
             else:
                 dic[var] = val
             return dic
-        if type == 'int':
-            value = int(datavalue)
-        elif type == 'float':
-            value = float(datavalue)
-        else:
-            value = datavalue
-        dict_to_update = get_dict_to_update(datavar, value)
-        update_datarepository(dict_to_update)
-        print_info("Value: {0} is stored in a Key:{1} of Warrior "
-                   "data_repository ".format(datavalue, datavar))
-        return True
+
+        status = False
+        pass_msg = "Value: {0} is stored in a Key: {1} of Warrior data_repository"
+
+        if datavar is not None and datavalue is not None:
+            if datatype == 'int':
+                datavalue = int(datavalue)
+            elif datatype == 'float':
+                datavalue = float(datavalue)
+            dict_to_update = get_dict_to_update(datavar, datavalue)
+            update_datarepository(dict_to_update)
+            print_info(pass_msg.format(datavalue, datavar))
+            status = True
+
+        if filepath is not None:
+            testcasefile_path = get_object_from_datarepository('wt_testcase_filepath')
+            try:
+                filepath = getAbsPath(filepath, os.path.dirname(testcasefile_path))
+                with open(filepath, "r") as json_handle:
+                    json_doc = json.load(json_handle)
+                    if jsonkey in json_doc:
+                        repo_dict = json_doc[jsonkey]
+                        for var_key, var_value in repo_dict.items():
+                            if isinstance(var_value, dict):
+                                if var_value.get('type') == 'int':
+                                    value = int(var_value['value'])
+                                elif var_value.get('type') == 'float':
+                                    value = float(var_value['value'])
+                                else:
+                                    value = str(var_value['value'])
+                            else:
+                                value = str(var_value)
+                            dict_to_update = get_dict_to_update(var_key, value)
+                            update_datarepository(dict_to_update)
+                            print_info(pass_msg.format(value, var_key))
+                    else:
+                        print_error('The {0} file is missing the key '
+                                    '\"repo_variables\", please refer to '
+                                    'the Samples in Config_files'.format(filepath))
+                status = True
+            except ValueError:
+                print_error('The file {0} is not a valid json '
+                            'file'.format(filepath))
+            except IOError:
+                print_error('The file {0} does not exist'.format(filepath))
+            except Exception as error:
+                print_error('Encountered {0} error'.format(error))
+
+        if (datatype is None or datavalue is None) and filepath is None:
+            print_error('Either Provide values to arguments \"datavar\" & '
+                        '\"datavalue\" or to argument \"filepath\"')
+
+        return status
 
     def verify_data(self, expected, object_key, type='str', comparison='eq'):
         """Verify value in 'object_key' in the data repository matches

--- a/warrior/Actions/CommonActions/common_actions.py
+++ b/warrior/Actions/CommonActions/common_actions.py
@@ -111,7 +111,7 @@ class CommonActions(object):
         Utils.testcase_Utils.report_substep_status(status)
         return status
 
-    def store_in_repo(self, datavar=None, datavalue=None, datatype='str',
+    def store_in_repo(self, datavar=None, datavalue=None, type='str',
                       filepath=None, jsonkey="repo_variables"):
         """Stores datavalue in datavar of datarepository
         :Argument:
@@ -120,7 +120,7 @@ class CommonActions(object):
                             i.e., if var is k1.k2.k3 then the data value would be
                             stored as a value in datarepository[k1][k2][k3]
             2. datavalue = Value to be stored
-            3. datatype = Type of datavalue(string/int/float)
+            3. type = Type of datavalue(string/int/float)
             4. filepath = Json file where datarepository variables are defined.
                           It is to store multiple key,value pairs in datarepository.
             5. jsonkey = The key where all the REPO variables & values are
@@ -132,6 +132,9 @@ class CommonActions(object):
                          "var1": {"type": "int", "value": "10"},
                          "var2.var3": {"value": "10"},
                          "var4.var5": "1"
+                         },
+                     "user_defined_tag":{
+                         "var6" : {"type": "int", "value": "40"}
                          }
                  }
             All three formats in the above sample block are allowed. If 'type'
@@ -159,9 +162,9 @@ class CommonActions(object):
         pass_msg = "Value: {0} is stored in a Key: {1} of Warrior data_repository"
 
         if datavar is not None and datavalue is not None:
-            if datatype == 'int':
+            if type == 'int':
                 datavalue = int(datavalue)
-            elif datatype == 'float':
+            elif type == 'float':
                 datavalue = float(datavalue)
             dict_to_update = get_dict_to_update(datavar, datavalue)
             update_datarepository(dict_to_update)
@@ -202,7 +205,7 @@ class CommonActions(object):
             except Exception as error:
                 print_error('Encountered {0} error'.format(error))
 
-        if (datatype is None or datavalue is None) and filepath is None:
+        if (type is None or datavalue is None) and filepath is None:
             print_error('Either Provide values to arguments \"datavar\" & '
                         '\"datavalue\" or to argument \"filepath\"')
 

--- a/warrior/Warriorspace/Config_files/Samples/Set_REPO_Variable_Sample.json
+++ b/warrior/Warriorspace/Config_files/Samples/Set_REPO_Variable_Sample.json
@@ -1,0 +1,11 @@
+{
+    "repo_variables": {
+        "var1": {"type": "int", "value": "10"},
+        "var2.var3": {"value": "20"},
+        "var4.var5": "30"
+        },
+
+    "user_defined_tag":{
+        "var6" : {"type": "int", "value": "40"}
+    }
+}

--- a/wftests/warrior_tests/testcases/common_actions_tests/verify_data_test.xml
+++ b/wftests/warrior_tests/testcases/common_actions_tests/verify_data_test.xml
@@ -3,9 +3,9 @@
         <Details>
                 <Name>verify_data_test</Name>
                 <Title>verify_data</Title>
-                <Engineer>suganya</Engineer>
-                <Date>2017-10-30</Date>
-                <Time>13:13</Time>
+                <Engineer>Warrior_user</Engineer>
+                <Date>2018-03-07</Date>
+                <Time>12:08</Time>
                 <State/>
                 <InputDataFile>No_Data</InputDataFile>
                 <Datatype/>
@@ -23,16 +23,16 @@
                                 <argument name="datavar" value="demovar.demochild.demograndchild"/>
                                 <argument name="datavalue" value="1"/>
                         </Arguments>
+                        <Execute ExecType="Yes">
+                                <Rule Condition="" Condvalue="" Operator="eq"/>
+                        </Execute>
                         <onError action="next"/>
                         <Description/>
                         <iteration_type type=""/>
-                        <Execute ExecType="Yes">
-                                <Rule Condition="" Condvalue="" Else="" Elsevalue=""/>
-                        </Execute>
                         <context>positive</context>
                         <impact>impact</impact>
                         <runmode type="Standard" value=""/>
-                        <Iteration_type type="Standard"/>
+                        <Iteration_type type="standard"/>
                 </step>
                 <step Driver="common_driver" Keyword="verify_data" TS="2" draft="no">
                         <Arguments>
@@ -41,75 +41,63 @@
                                 <argument name="type" value="int"/>
                                 <argument name="object_key" value="demovar.demochild.demograndchild"/>
                         </Arguments>
+                        <Execute ExecType="Yes"/>
                         <onError action="next"/>
                         <Description/>
                         <iteration_type type=""/>
-                        <Execute ExecType="Yes">
-                                <Rule Condition="" Condvalue="" Else="" Elsevalue=""/>
-                        </Execute>
                         <context>negative</context>
                         <impact>impact</impact>
                         <runmode type="Standard" value=""/>
-                        <Iteration_type type="Standard"/>
                 </step>
                 <step Driver="common_driver" Keyword="verify_data" TS="3" draft="no">
                         <Arguments>
                                 <argument name="expected" value="1"/>
                                 <argument name="object_key" value="demovar.demochild.demograndchild"/>
                         </Arguments>
+                        <Execute ExecType="Yes"/>
                         <onError action="next"/>
                         <Description/>
                         <iteration_type type=""/>
-                        <Execute ExecType="Yes">
-                                <Rule Condition="" Condvalue="" Else="" Elsevalue=""/>
-                        </Execute>
                         <context>positive</context>
                         <impact>impact</impact>
                         <runmode type="Standard" value=""/>
-                        <Iteration_type type="Standard"/>
                 </step>
                 <step Driver="common_driver" Keyword="store_in_repo" TS="4" draft="no">
                         <Arguments>
                                 <argument name="datavar" value="demovar"/>
                                 <argument name="datavalue" value="demovalue"/>
                         </Arguments>
+                        <Execute ExecType="Yes"/>
                         <onError action="next"/>
                         <Description/>
                         <iteration_type type=""/>
-                        <Execute ExecType="Yes">
-                                <Rule Condition="" Condvalue="" Else="" Elsevalue=""/>
-                        </Execute>
                         <context>positive</context>
                         <impact>impact</impact>
                         <runmode type="Standard" value=""/>
-                        <Iteration_type type="Standard"/>
                 </step>
                 <step Driver="common_driver" Keyword="verify_data" TS="5" draft="no">
                         <Arguments>
                                 <argument name="expected" value="demovalue"/>
-                                <argument name="object_key" value="demovar"/>
                                 <argument name="comparison" value="eq"/>
+                                <argument name="object_key" value="demovar"/>
                         </Arguments>
+                        <Execute ExecType="Yes"/>
                         <onError action="next"/>
                         <Description/>
                         <iteration_type type=""/>
-                        <Execute ExecType="Yes">
-                                <Rule Condition="" Condvalue="" Else="" Elsevalue=""/>
-                        </Execute>
                         <context>positive</context>
                         <impact>impact</impact>
                         <runmode type="Standard" value=""/>
-                        <Iteration_type type="Standard"/>
                 </step>
                 <step Driver="common_driver" Keyword="verify_data" TS="6" draft="no">
                         <Arguments>
                                 <argument name="expected" value="1"/>
                                 <argument name="object_key" value="demovar"/>
                         </Arguments>
+                        <Execute ExecType="Yes"/>
                         <onError action="next"/>
                         <Description/>
                         <iteration_type type=""/>
-                        <Execute ExecType="Yes"/>
                         <context>negative</context>
                         <impact>impact</impact>
                         <runmode type="Standard" value=""/>
@@ -119,32 +107,26 @@
                                 <argument name="datavar" value="demovar.demochild"/>
                                 <argument name="datavalue" value="demovalue"/>
                         </Arguments>
+                        <Execute ExecType="Yes"/>
                         <onError action="next"/>
                         <Description/>
                         <iteration_type type=""/>
-                        <Execute ExecType="Yes">
-                                <Rule Condition="" Condvalue="" Else="" Elsevalue=""/>
-                        </Execute>
                         <context>positive</context>
                         <impact>impact</impact>
                         <runmode type="Standard" value=""/>
-                        <Iteration_type type="Standard"/>
                 </step>
                 <step Driver="common_driver" Keyword="verify_data" TS="8" draft="no">
                         <Arguments>
                                 <argument name="expected" value="demovalue"/>
                                 <argument name="object_key" value="demovar.demochild"/>
                         </Arguments>
+                        <Execute ExecType="Yes"/>
                         <onError action="next"/>
                         <Description/>
                         <iteration_type type=""/>
-                        <Execute ExecType="Yes">
-                                <Rule Condition="" Condvalue="" Else="" Elsevalue=""/>
-                        </Execute>
                         <context>positive</context>
                         <impact>impact</impact>
                         <runmode type="Standard" value=""/>
-                        <Iteration_type type="Standard"/>
                 </step>
                 <step Driver="common_driver" Keyword="verify_data" TS="9" draft="no">
                         <Arguments>
@@ -152,16 +134,93 @@
                                 <argument name="type" value="int"/>
                                 <argument name="object_key" value="demovar.demochild"/>
                         </Arguments>
+                        <Execute ExecType="Yes"/>
                         <onError action="next"/>
                         <Description/>
                         <iteration_type type=""/>
-                        <Execute ExecType="Yes">
-                                <Rule Condition="" Condvalue="" Else="" Elsevalue=""/>
-                        </Execute>
                         <context>negative</context>
                         <impact>impact</impact>
                         <runmode type="Standard" value=""/>
-                        <Iteration_type type="Standard"/>
+                </step>
+                <step Driver="common_driver" Keyword="store_in_repo" TS="10" draft="no">
+                        <Arguments>
+                                <argument name="filepath" value="../../../../warrior/Warriorspace/Config_files/Samples/Set_REPO_Variable_Sample.json"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description>Using filepath(json file) option to store multiple REPO values(default json tag)</Description>
+                        <iteration_type type="Standard"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+                </step>
+                <step Driver="common_driver" Keyword="verify_data" TS="11" draft="no">
+                        <Arguments>
+                                <argument name="expected" value="10"/>
+                                <argument name="type" value="int"/>
+                                <argument name="object_key" value="var1"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description>Comparing integer value with another repo integer value(stored using json file)</Description>
+                        <iteration_type type="Standard"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+                </step>
+                <step Driver="common_driver" Keyword="verify_data" TS="12" draft="no">
+                        <Arguments>
+                                <argument name="expected" value="20"/>
+                                <argument name="type" value="int"/>
+                                <argument name="object_key" value="var2.var3"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description>Comparing integer value with a repo string value(stored using json file), It will fail</Description>
+                        <iteration_type type="Standard"/>
+                        <context>negative</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+                </step>
+                <step Driver="common_driver" Keyword="verify_data" TS="13" draft="no">
+                        <Arguments>
+                                <argument name="expected" value="30"/>
+                                <argument name="object_key" value="var4.var5"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description>Comparing a string value with repo string value(stored using json file)</Description>
+                        <iteration_type type="Standard"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+                </step>
+                <step Driver="common_driver" Keyword="store_in_repo" TS="14" draft="no">
+                        <Arguments>
+                                <argument name="filepath" value="../../../../warrior/Warriorspace/Config_files/Samples/Set_REPO_Variable_Sample.json"/>
+                                <argument name="jsonkey" value="user_defined_tag"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description>Using filepath(json file) option to store multiple REPO values(use-defined json tag)</Description>
+                        <iteration_type type="Standard"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+                </step>
+                <step Driver="common_driver" Keyword="verify_data" TS="15" draft="no">
+                        <Arguments>
+                                <argument name="expected" value="40"/>
+                                <argument name="object_key" value="var6"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description/>
+                        <iteration_type type="Standard"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
                 </step>
         </Steps>
 </Testcase>


### PR DESCRIPTION
Requirement is to support storing multiple values in data_repository using 'store_in_repo' kw by passing a file.
Similar support is already available in set_env_var kw by passing json file, same logic is used here.
Test instructions & Regression results are available in Jira ticket