### PR TITLE
WAR-1685 : Need Result HTML link during the start of execution

### DIFF
--- a/warrior/WarriorCore/Classes/html_results_class.py
+++ b/warrior/WarriorCore/Classes/html_results_class.py
@@ -105,7 +105,7 @@ class LineResult:
 
 
 class WarriorHtmlResults:
-    """Class that generates html results using hte junit result file """
+    """Class that generates html results using the junit result file """
     lineObjs = []
     lineCount = 0
     recount = 0
@@ -179,7 +179,7 @@ class WarriorHtmlResults:
 	    user = "Unknown_user"
         return '<div class="user">' + user + '</div>'
 
-    def generate_html(self, junitObj, givenPath):
+    def generate_html(self, junitObj, givenPath, print_summary=False):
         """ build the html givenPath: added this feature in case of later down the line
         calling from outside junit file ( no actual use as of now )
         """
@@ -199,8 +199,10 @@ class WarriorHtmlResults:
         elem_file.write(html)
         elem_file.close()
         self.lineObjs = []
-        print_info("++++ Results Summary ++++")
-        print_info("Open the Results summary file given below in a browser to "
-                   "view results summary for this execution")
-        print_info("Results sumary file: {0}".format(self.get_path()))
-        print_info("+++++++++++++++++++++++++")
+        # Prints result summary at the end of execution
+        if print_summary is True:
+            print_info("++++ Results Summary ++++")
+            print_info("Open the Results summary file given below in a browser to "
+                       "view results summary for this execution")
+            print_info("Results summary file: {0}".format(self.get_path()))
+            print_info("+++++++++++++++++++++++++")

--- a/warrior/WarriorCore/Classes/junit_class.py
+++ b/warrior/WarriorCore/Classes/junit_class.py
@@ -237,7 +237,7 @@ class Junit(object):
         """ Convert junit file to html"""
         if not hasattr(self, 'html_result_obj'):
             self.html_result_obj = WarriorHtmlResults(junit_file)
-        self.html_result_obj.generate_html(junit_file, None)
+        self.html_result_obj.generate_html(junit_file, None, print_summary)
 
     def remove_html_obj(self):
         """checks and removes html_results_obj from junit object usecase in parralel execution"""

--- a/warrior/WarriorCore/project_driver.py
+++ b/warrior/WarriorCore/project_driver.py
@@ -207,8 +207,7 @@ def execute_project(project_filepath, auto_defects, jiraproj, res_startdir, logs
         filename = os.path.basename(project_filepath)
         html_filepath = os.path.join(project_repository['project_execution_dir'],
                                      Utils.file_Utils.getNameOnly(filename))+'.html'
-        print_info("Warrior execution results will be updated "
-                   "simultaneously in {0}".format(html_filepath))
+        print_info("HTML result file: {0}".format(html_filepath))
 
     # project_resultfile = project_repository['project_resultfile']
 

--- a/warrior/WarriorCore/project_driver.py
+++ b/warrior/WarriorCore/project_driver.py
@@ -202,6 +202,16 @@ def execute_project(project_filepath, auto_defects, jiraproj, res_startdir, logs
                                              data_repository)
     project_repository['project_title'] = project_title
     testsuite_list = get_testsuite_list(project_filepath)
+    # Prints the path of result summary file at the beginning of execution
+    filename = os.path.basename(project_filepath)
+    if data_repository['war_file_type'] == "Project":
+        html_filepath = os.path.join(project_repository['project_execution_dir'],
+                                     Utils.file_Utils.getNameOnly(filename))+'.html'
+        print_info("++++++++++++++  Result Summary  +++++++++++++++")
+        print_info("Open the result summary file in a browser to view result "
+                   "summary which will be updated along with the execution")
+        print_info("Result summary file: {0}".format(html_filepath))
+        print_info("+++++++++++++++++++++++++++++++++++++++++++++++")
 
     # project_resultfile = project_repository['project_resultfile']
 

--- a/warrior/WarriorCore/project_driver.py
+++ b/warrior/WarriorCore/project_driver.py
@@ -203,15 +203,12 @@ def execute_project(project_filepath, auto_defects, jiraproj, res_startdir, logs
     project_repository['project_title'] = project_title
     testsuite_list = get_testsuite_list(project_filepath)
     # Prints the path of result summary file at the beginning of execution
-    filename = os.path.basename(project_filepath)
     if data_repository['war_file_type'] == "Project":
+        filename = os.path.basename(project_filepath)
         html_filepath = os.path.join(project_repository['project_execution_dir'],
                                      Utils.file_Utils.getNameOnly(filename))+'.html'
-        print_info("++++++++++++++  Result Summary  +++++++++++++++")
-        print_info("Open the result summary file in a browser to view result "
-                   "summary which will be updated along with the execution")
-        print_info("Result summary file: {0}".format(html_filepath))
-        print_info("+++++++++++++++++++++++++++++++++++++++++++++++")
+        print_info("Warrior execution results will be updated "
+                   "simultaneously in {0}".format(html_filepath))
 
     # project_resultfile = project_repository['project_resultfile']
 

--- a/warrior/WarriorCore/testcase_driver.py
+++ b/warrior/WarriorCore/testcase_driver.py
@@ -486,6 +486,16 @@ def execute_testcase(testcase_filepath, data_repository, tc_context,
 
     data_repository['wt_junit_object'] = tc_junit_object
     print_testcase_details_to_console(testcase_filepath, data_repository)
+    filename = os.path.basename(testcase_filepath)
+    # Prints the path of result summary file at the beginning of execution
+    if data_repository['war_file_type'] == "Case":
+        html_filepath = os.path.join(data_repository['wt_resultsdir'],
+                                     Utils.file_Utils.getNameOnly(filename)) + '.html'
+        print_info("++++++++++++++  Result Summary  +++++++++++++++")
+        print_info("Open the result summary file in a browser to view result "
+                   "summary which will be updated along with the execution")
+        print_info("Result summary file: {0}".format(html_filepath))
+        print_info("+++++++++++++++++++++++++++++++++++++++++++++++")
     step_list = get_steps_list(testcase_filepath)
 
     tc_state = Utils.xml_Utils.getChildTextbyParentTag(testcase_filepath,

--- a/warrior/WarriorCore/testcase_driver.py
+++ b/warrior/WarriorCore/testcase_driver.py
@@ -491,8 +491,7 @@ def execute_testcase(testcase_filepath, data_repository, tc_context,
         filename = os.path.basename(testcase_filepath)
         html_filepath = os.path.join(data_repository['wt_resultsdir'],
                                      Utils.file_Utils.getNameOnly(filename)) + '.html'
-        print_info("Warrior execution results will be updated "
-                   "simultaneously in {0}".format(html_filepath))
+        print_info("HTML result file: {0}".format(html_filepath))
     step_list = get_steps_list(testcase_filepath)
 
     tc_state = Utils.xml_Utils.getChildTextbyParentTag(testcase_filepath,

--- a/warrior/WarriorCore/testcase_driver.py
+++ b/warrior/WarriorCore/testcase_driver.py
@@ -486,16 +486,13 @@ def execute_testcase(testcase_filepath, data_repository, tc_context,
 
     data_repository['wt_junit_object'] = tc_junit_object
     print_testcase_details_to_console(testcase_filepath, data_repository)
-    filename = os.path.basename(testcase_filepath)
     # Prints the path of result summary file at the beginning of execution
     if data_repository['war_file_type'] == "Case":
+        filename = os.path.basename(testcase_filepath)
         html_filepath = os.path.join(data_repository['wt_resultsdir'],
                                      Utils.file_Utils.getNameOnly(filename)) + '.html'
-        print_info("++++++++++++++  Result Summary  +++++++++++++++")
-        print_info("Open the result summary file in a browser to view result "
-                   "summary which will be updated along with the execution")
-        print_info("Result summary file: {0}".format(html_filepath))
-        print_info("+++++++++++++++++++++++++++++++++++++++++++++++")
+        print_info("Warrior execution results will be updated "
+                   "simultaneously in {0}".format(html_filepath))
     step_list = get_steps_list(testcase_filepath)
 
     tc_state = Utils.xml_Utils.getChildTextbyParentTag(testcase_filepath,

--- a/warrior/WarriorCore/testsuite_driver.py
+++ b/warrior/WarriorCore/testsuite_driver.py
@@ -361,6 +361,16 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
 
     print_suite_details_to_console(suite_repository, testsuite_filepath, junit_resultfile)
 
+    # Prints the path of result summary file at the beginning of execution
+    filename = os.path.basename(testsuite_filepath)
+    if data_repository['war_file_type'] == "Suite":
+        html_filepath = os.path.join(suite_repository['suite_execution_dir'],
+                                     Utils.file_Utils.getNameOnly(filename))+'.html'
+        print_info("++++++++++++++  Result Summary  +++++++++++++++")
+        print_info("Open the result summary file in a browser to view result "
+                   "summary which will be updated along with the execution")
+        print_info("Result summary file: {0}".format(html_filepath))
+        print_info("+++++++++++++++++++++++++++++++++++++++++++++++")
     if not from_project:
         data_repository["war_parallel"] = False
 

--- a/warrior/WarriorCore/testsuite_driver.py
+++ b/warrior/WarriorCore/testsuite_driver.py
@@ -366,8 +366,7 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
         filename = os.path.basename(testsuite_filepath)
         html_filepath = os.path.join(suite_repository['suite_execution_dir'],
                                      Utils.file_Utils.getNameOnly(filename))+'.html'
-        print_info("Warrior execution results will be updated "
-                   "simultaneously in {0}".format(html_filepath))
+        print_info("HTML result file: {0}".format(html_filepath))
     if not from_project:
         data_repository["war_parallel"] = False
 

--- a/warrior/WarriorCore/testsuite_driver.py
+++ b/warrior/WarriorCore/testsuite_driver.py
@@ -362,15 +362,12 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
     print_suite_details_to_console(suite_repository, testsuite_filepath, junit_resultfile)
 
     # Prints the path of result summary file at the beginning of execution
-    filename = os.path.basename(testsuite_filepath)
     if data_repository['war_file_type'] == "Suite":
+        filename = os.path.basename(testsuite_filepath)
         html_filepath = os.path.join(suite_repository['suite_execution_dir'],
                                      Utils.file_Utils.getNameOnly(filename))+'.html'
-        print_info("++++++++++++++  Result Summary  +++++++++++++++")
-        print_info("Open the result summary file in a browser to view result "
-                   "summary which will be updated along with the execution")
-        print_info("Result summary file: {0}".format(html_filepath))
-        print_info("+++++++++++++++++++++++++++++++++++++++++++++++")
+        print_info("Warrior execution results will be updated "
+                   "simultaneously in {0}".format(html_filepath))
     if not from_project:
         data_repository["war_parallel"] = False
 


### PR DESCRIPTION
Requirement : 
User requires the HTML file link while starting the Project/Suite/Case. So that he/she could do real time monitoring during execution.

Fix Explanation: 
Made the Result summary file(HTML file link) to get printed only at the beginning and end of the execution and removed the same(Result summary file) which was earlier printed at the end of each step.

Attached the regression logs and added the instruction for testing in JIRA.