### PR TITLE
WAR-1358: print_warning creates two print 1. -W- "Warning 2. -I- Information

### DIFF
--- a/warrior/WarriorCore/Classes/testcase_utils_class.py
+++ b/warrior/WarriorCore/Classes/testcase_utils_class.py
@@ -195,7 +195,7 @@ class TestcaseUtils(object):
         """Create Note at the provided level"""
         write_locn = self.get_write_locn(str(level).upper())
         print_util_types = ["-D-", "", "-I-", "-E-", "-W-",
-                            "\033[1;31m-E-\033[0m"]
+                            "\033[1;31m-E-\033[0m", "\x1b[1;33m-W-\x1b[0m"]
         p_type = {'INFO': print_info,
                   'DEBUG': print_debug,
                   'WARN': print_warning,

--- a/warrior/WarriorCore/Classes/testcase_utils_class.py
+++ b/warrior/WarriorCore/Classes/testcase_utils_class.py
@@ -195,7 +195,7 @@ class TestcaseUtils(object):
         """Create Note at the provided level"""
         write_locn = self.get_write_locn(str(level).upper())
         print_util_types = ["-D-", "", "-I-", "-E-", "-W-",
-                            "\033[1;31m-E-\033[0m", "\x1b[1;33m-W-\x1b[0m"]
+                            "\033[1;31m-E-\033[0m", "\033[1;33m-W-\033[0m"]
         p_type = {'INFO': print_info,
                   'DEBUG': print_debug,
                   'WARN': print_warning,


### PR DESCRIPTION
Issue: 
------
Two print messages being logged in case of a print_warning(). 

Fix:
---
- The print_warning() calls print_main() which has a call to p_note_level()(WarriorCore/Classes/testcase_utils_class.py).
- p_note_level() maintains a print_util_types [] list, which has the supported print_types.
- The print_util_types [] list currently holds only white color code for warning ['-W-'].  
- As warning message is printed in different color, added the -W- type with its color coding ["\033[1;33m-W-\033[0m"] to the print_util_types [] list in the p_note_level () method.

Added the logs in JIRA
