### PR TITLE
WAR-1718: HTML Result summary attachment is huge - Need to be Zipped and compressed format

### DIFF
--- a/warrior/Framework/Utils/email_utils.py
+++ b/warrior/Framework/Utils/email_utils.py
@@ -165,6 +165,8 @@ def compose_send_email(exec_type, abs_filepath, logs_dir, results_dir, result,
                 (1) per_execution(default)
                 (2) first_failure
                 (3) every_failure
+        7. compress - specifies if the result has to be compressed and emailed.
+           Supported options: Yes/No(default)
     """
     resultconverted = {"True": "Pass", "False": "Fail", "ERROR": "Error",
                        "EXCEPTION": "Exception"}.get(str(result))
@@ -176,12 +178,11 @@ def compose_send_email(exec_type, abs_filepath, logs_dir, results_dir, result,
     element = ET.parse(warrior_tools_dir)
     setting_elem = element.find("Setting[@name='mail_to']")
     if setting_elem is not None:
-        co = setting_elem.get("compress")
-        if "Yes" in co:
+        compress = setting_elem.get("compress")
+        if "Yes" in compress:
             report_attachment += ".zip"
         else:
             report_attachment += ".html"
-    print "##### report to be pritnted : ", report_attachment
     # Temporary fix - HTML file can not be attached since it will be generated
     # only after the completion of the warrior execution. Creating html result
     # file at runtime will solve this.

--- a/warrior/Framework/Utils/email_utils.py
+++ b/warrior/Framework/Utils/email_utils.py
@@ -171,8 +171,17 @@ def compose_send_email(exec_type, abs_filepath, logs_dir, results_dir, result,
     subject = str(resultconverted)+": "+file_Utils.getFileName(abs_filepath)
     body = construct_mail_body(exec_type, abs_filepath, logs_dir, results_dir)
     report_attachment = results_dir + os.sep + \
-        file_Utils.getNameOnly(file_Utils.getFileName(abs_filepath)) + ".html"
-
+               file_Utils.getNameOnly(file_Utils.getFileName(abs_filepath)) 
+    warrior_tools_dir = Tools.__path__[0]+os.sep+'w_settings.xml'
+    element = ET.parse(warrior_tools_dir)
+    setting_elem = element.find("Setting[@name='mail_to']")
+    if setting_elem is not None:
+        co = setting_elem.get("compress")
+        if "Yes" in co:
+            report_attachment += ".zip"
+        else:
+            report_attachment += ".html"
+    print "##### report to be pritnted : ", report_attachment
     # Temporary fix - HTML file can not be attached since it will be generated
     # only after the completion of the warrior execution. Creating html result
     # file at runtime will solve this.

--- a/warrior/Tools/w_settings.xml
+++ b/warrior/Tools/w_settings.xml
@@ -13,7 +13,12 @@
             2. first_failure - to send an email as soon as the first failure occurs during suite/project execution
             3. every_failure - to send an email whenever a case fails during suite/project execution
          When 'mail_on attribute' is not given or left empty, default value will be used for sending email.
-         It also accepts comma separated values, example mail_on="per_execution, first_failure" -->
+         It also accepts comma separated values, example mail_on="per_execution, first_failure"
+         
+         'compress' attribute is to specify whether the result file should be emailed in a compressed format.
+          Supported Values:
+           1. No(default): to send the result file as is,i.e, in .html format
+           2. Yes: To compress the result file and email in .zip format -->
         <smtp_host></smtp_host> <!-- Name of the host running your SMTP server(IP address or DNS name) -->
         <sender></sender> <!-- Sender email id -->
         <receiver></receiver> <!-- Receiver(s) email id, use comma to separate multiple receivers -->

--- a/warrior/Tools/w_settings.xml
+++ b/warrior/Tools/w_settings.xml
@@ -7,7 +7,7 @@
     <Setting name="job_url">
         <url></url>
     </Setting>
-    <Setting name="mail_to" mail_on="">
+    <Setting name="mail_to" mail_on="" compress="No">
     <!-- 'mail_on' attribute is to specify 'when to send an email'. Supported values are 'per_execution, first_failure & every_failure'.
             1. per_execution(default) - to send an email after the end of case/suite/project execution
             2. first_failure - to send an email as soon as the first failure occurs during suite/project execution

--- a/warrior/WarriorCore/Classes/html_results_class.py
+++ b/warrior/WarriorCore/Classes/html_results_class.py
@@ -167,9 +167,9 @@ class WarriorHtmlResults:
     def zip_html_result(self, htmlfile):
         """ Compressing and zipping the html result file """
         html_zipfile = htmlfile.split(".html")[0] + ".zip"
-        z = zipfile.ZipFile(html_zipfile, 'w', zipfile.ZIP_DEFLATED)
-        z.write(htmlfile)
-        z.close()
+        zippedfile = zipfile.ZipFile(html_zipfile, 'w', zipfile.ZIP_DEFLATED)
+        zippedfile.write(htmlfile)
+        zippedfile.close()
         return html_zipfile
 
     def get_war_version(self):
@@ -208,16 +208,15 @@ class WarriorHtmlResults:
         elem_file.write(html)
         elem_file.close()
         self.lineObjs = []
-        #get the value of compression in w_settings.xml
+        # Check whether the result file has to be compressed 
         resultPath = self.get_path()
         warrior_tools_dir = Tools.__path__[0]+os.sep+'w_settings.xml'
         element = ET.parse(warrior_tools_dir)
         setting_elem = element.find("Setting[@name='mail_to']")
         if setting_elem is not None:
-            co = setting_elem.get("compress")
-            print "Enable compression: ", co
-            if "Yes" in co:
-                print "Compressing the result html file: "
+            compress = setting_elem.get("compress")
+            print_info("Enable compression: ", compress)
+            if "Yes" in compress:
                 zipfile = self.zip_html_result(resultPath)
                 resultPath = zipfile
 


### PR DESCRIPTION
Issue:
-----
When a project is executed with the mail settings. It sends mail with huge Result HTML attachments. (5-7 MB).
- Mail is getting delayed for hours after execution.
- Inbox will soon get flooded with huge mails.

Fix:
---

- Introduced a user-driven approach to compress the result .html file and e-mail the zipped version of it.
- The user can enable/disable this option on need basis.

Attaching logs in JIRA
