### PR TITLE
WAR-1381: Not getting executed for y number of systems specified in ID file (when ID is passed using CLI command)

### DIFF
--- a/warrior/WarriorCore/testsuite_driver.py
+++ b/warrior/WarriorCore/testsuite_driver.py
@@ -471,10 +471,6 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
     suite_end_time = Utils.datetime_utils.get_current_timestamp()
     print_info("[{0}] Testsuite execution completed".format(suite_end_time))
     suite_duration = Utils.datetime_utils.get_time_delta(suite_start_time)
-    if execution_type.upper() == "ITERATIVE_SEQUENTIAL":
-        data_repository["suite_duration_seq"]=suite_duration
-    elif execution_type.upper() == "ITERATIVE_PARALLEL":
-        data_repository["suite_duration_par"]=suite_duration
     hms = Utils.datetime_utils.get_hms_for_seconds(suite_duration)
     print_info("Testsuite duration= {0}".format(hms))
     testsuite_utils.update_suite_duration(str(suite_duration))

--- a/warrior/WarriorCore/testsuite_driver.py
+++ b/warrior/WarriorCore/testsuite_driver.py
@@ -98,7 +98,11 @@ def get_suite_details(testsuite_filepath, data_repository, from_project,
 
     efile_obj = execution_files_class.ExecFilesClass(testsuite_filepath, "ts",
                                                      res_startdir, logs_startdir)
-    data_file = efile_obj.get_data_files()[0]
+    # First priority for data files given through CLI##
+    if data_repository.has_key('ow_datafile'):
+        data_file = data_repository['ow_datafile']
+    else:
+        data_file = efile_obj.get_data_files()[0]
     suite_resultfile = efile_obj.resultfile
     suite_execution_dir = os.path.dirname(suite_resultfile)
     junit_resultfile = (Utils.file_Utils.getNameOnly(suite_resultfile) +

--- a/warrior/WarriorCore/testsuite_driver.py
+++ b/warrior/WarriorCore/testsuite_driver.py
@@ -471,6 +471,10 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
     suite_end_time = Utils.datetime_utils.get_current_timestamp()
     print_info("[{0}] Testsuite execution completed".format(suite_end_time))
     suite_duration = Utils.datetime_utils.get_time_delta(suite_start_time)
+    if execution_type.upper() == "ITERATIVE_SEQUENTIAL":
+        data_repository["suite_duration_seq"]=suite_duration
+    elif execution_type.upper() == "ITERATIVE_PARALLEL":
+        data_repository["suite_duration_par"]=suite_duration
     hms = Utils.datetime_utils.get_hms_for_seconds(suite_duration)
     print_info("Testsuite duration= {0}".format(hms))
     testsuite_utils.update_suite_duration(str(suite_duration))

--- a/warrior/WarriorCore/testsuite_driver.py
+++ b/warrior/WarriorCore/testsuite_driver.py
@@ -98,7 +98,10 @@ def get_suite_details(testsuite_filepath, data_repository, from_project,
 
     efile_obj = execution_files_class.ExecFilesClass(testsuite_filepath, "ts",
                                                      res_startdir, logs_startdir)
-    # First priority for data files given through CLI##
+    # First priority is given for data files specified via CLI
+    # Default datafiles: Given in the test suite globally.
+    # If no datafiles are specified at CLI or global level, error is thrown.
+    # At Suite level execution, step-wise datafiles are not considered.
     if data_repository.has_key('ow_datafile'):
         data_file = data_repository['ow_datafile']
     else:


### PR DESCRIPTION
Issue:

- Datafile provided in cmd line should take precedence over the file given at the suite level which is not happening for iterative(parallel/sequential) execution.
- In IterativeTestsuite class(iterative_testsuite_class.py) constructor method, we use the datafile given in 
y) constructor method, we use the datafile given in the suite file for getting the list of systems for iteration instead of the one given at cmd line.

Fix:

- First priority is given for data files specified via CLI
- Default datafiles are the ones specified in the test suite globally.
- If no datafiles are specified at CLI or global level, error is thrown.
- At Suite level execution, step-wise datafiles are not considered.

Testcase validation:

- Verified the fix with the sequential suite:
   wftests/warrior_tests/suites/framework_tests/iter_execution/ts_iter_seq.xml
- This suite has 3 systems to create 3 tmp files.
- Make a copy of this data file with only 2 systems and pass the datafile in CLI. 
- The test should run only for 2 systems.
- Same is applicable for parallel suite also.  