### PR TITLE
WAR-1650: Need to change the way warhorn clones repositories in order to support cloning private repositories

### DIFF
--- a/warhorn/default_config.xml
+++ b/warhorn/default_config.xml
@@ -37,7 +37,8 @@
 
     Fill this out with the details of the repository that you want to clone
 
-    <tools url="http://repository/one/url.git" overwrite="yes" clone="yes">
+    <tools url="http://repository/one/url.git" overwrite="yes" clone="yes"
+           label="" username="" password="">
     </tools>
 
     -->
@@ -48,7 +49,8 @@
 
         Fill this out with the details of the repository that you want to clone
 
-        <repository url="http://repository/one/url.git" clone="yes" label="tag-name" all_drivers="no">
+        <repository url="http://repository/one/url.git" clone="yes" label="tag-name" all_drivers="no"
+                    username="" password="">
             <driver name="driver_one_name" clone="yes"/>
 			<driver name="driver_two_name" clone=""/>
 			<driver name="driver_three_name" clone="no"/>
@@ -65,7 +67,8 @@
 
         Fill this out with the details of the repository that you want to clone
 
-        <repository url="http://warriorspace/repository/url.git" overwrite="no" label="commit-id" clone="yes">
+        <repository url="http://warriorspace/repository/url.git" overwrite="no" label="commit-id" clone="yes"
+                    username="" password="">
         </repository>
 
         -->

--- a/warhorn/source/utils.py
+++ b/warhorn/source/utils.py
@@ -21,6 +21,7 @@ import imp
 import subprocess
 import datetime
 import sys
+import urllib
 from war_print_class import print_main
 """
 Utility functions for warhorn.py
@@ -786,3 +787,39 @@ def git_checkout_label(label, base_path="", current_dir=""):
     if current_dir != "":
         os.chdir(current_dir)
     return check, current_label
+
+
+def embed_user_cred_in_url(url, username, password):
+    """
+    Embed the username and password in the git url.
+    It is applicable only for http or https url types.
+    Input url format: https://path/to/repo (or) https://username@path/to/repo
+    Output url format: https://username:password@path/to/repo
+    If the username is already given in the url, that will be used.
+
+    :Arguments:
+        1. url(string) - url to be used for cloning
+        2. username(string) - git username
+        3. password(string) - git password
+    :Returns:
+        1. url(string) - url with username and password
+    """
+    url_parts = url.split("://", 1)
+    # check if the url type is http or https
+    if len(url_parts) == 2 and url_parts[0].upper() in ["HTTP", "HTTPS"]:
+        url_type, url_path = url_parts[0], url_parts[1]
+        # get the username from the URL
+        if '@' in url_path:
+            url_username, url_path = url_path.split('@', 1)
+        else:
+            url_username = ""
+
+        if url_username != "":
+            username = url_username
+        # modify url to include username and password in it
+        # format: http[s]://username:password@path/to/repo
+        if username != "" and password != "":
+            username = urllib.quote_plus(username)
+            password = urllib.quote_plus(password)
+            url = url_type + "://" + username + ":" + password + '@' + url_path
+    return url

--- a/warhorn/user_generated/config_sample.xml
+++ b/warhorn/user_generated/config_sample.xml
@@ -76,6 +76,16 @@
         ** label: This is an attribute can be set to reflect the name of the
         branch, or tag, or commit-id that the user wants to checkout.
 
+        ** username: It is to specify the username of the repository to
+        be cloned. It is applicable only for http or https url types, leave
+        it empty for other url types. If the username is provided in the url
+        itself, that will be used instead of the value specified in the
+        username attribute.
+
+        ** password: It is to specify the password of the repository to
+        be cloned. It is applicable only for http or https url types, leave
+        it empty other url types.
+
         ** all_drivers: If the user wants to clone all the drivers in the
         repository, s/he can set this tag to 'yes'.
 
@@ -132,6 +142,17 @@
 
         ** label: This is an attribute can be set to reflect the name of the
         branch, or tag, or commit-id that the user wants to checkout.
+
+        ** username: It is to specify the username of the repository to
+        be cloned. It is applicable only for http or https url types, leave
+        it empty for other url types. If the username is provided in the url
+        itself, that will be used instead of the value specified in the
+        username attribute.
+
+        ** password: It is to specify the password of the repository to
+        be cloned. It is applicable only for http or https url types, leave
+        it empty other url types.
+
         -->
 
 		<!-- Sample

--- a/warhorn/warhorn.py
+++ b/warhorn/warhorn.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import subprocess
 import sys
+import urllib
 from distutils import dir_util
 from source.utils import (check_installed_python_version, print_info, verify_python_version,
                           check_packages, print_warning, print_error, get_subfiles, create_dir,
@@ -658,6 +659,14 @@ def clone_drivers(base_path, current_dir, **kwargs):
                 continue
             url = get_attribute_value(repository, "url")
             name = get_repository_name(url)
+            username = get_attribute_value(repository, "username")
+            password = get_attribute_value(repository, "password")
+
+            if username and password:
+                url_list = url.split("//", 1)
+                username = urllib.quote_plus(username)
+                password = urllib.quote_plus(password)
+                url = url_list[0] + "//" + username + ":" + password + '@' + url_list[1]
 
             # url validation
             if url == "":

--- a/warhorn/warhorn.py
+++ b/warhorn/warhorn.py
@@ -659,14 +659,16 @@ def clone_drivers(base_path, current_dir, **kwargs):
                 continue
             url = get_attribute_value(repository, "url")
             name = get_repository_name(url)
+
             username = get_attribute_value(repository, "username")
             password = get_attribute_value(repository, "password")
-
-            if username and password:
-                url_list = url.split("//", 1)
+            url_parts = url.split("://", 1)
+            # modify http/https url to include username and password in it
+            # format: https://username:password@path/to/repo
+            if all([username, password, url_parts[0].upper() in ["HTTP", "HTTPS"]]):
                 username = urllib.quote_plus(username)
                 password = urllib.quote_plus(password)
-                url = url_list[0] + "//" + username + ":" + password + '@' + url_list[1]
+                url = url_parts[0] + "://" + username + ":" + password + '@' + url_parts[1]
 
             # url validation
             if url == "":

--- a/warhorn/warhorn.py
+++ b/warhorn/warhorn.py
@@ -660,15 +660,26 @@ def clone_drivers(base_path, current_dir, **kwargs):
             url = get_attribute_value(repository, "url")
             name = get_repository_name(url)
 
-            username = get_attribute_value(repository, "username")
-            password = get_attribute_value(repository, "password")
             url_parts = url.split("://", 1)
-            # modify http/https url to include username and password in it
-            # format: https://username:password@path/to/repo
-            if all([username, password, url_parts[0].upper() in ["HTTP", "HTTPS"]]):
-                username = urllib.quote_plus(username)
-                password = urllib.quote_plus(password)
-                url = url_parts[0] + "://" + username + ":" + password + '@' + url_parts[1]
+            # username and password applicable for http & https
+            if len(url_parts) == 2 and url_parts[0].upper() in ["HTTP", "HTTPS"]:
+                url_type, url_path = url_parts[0], url_parts[1]
+                # get the username from the URL
+                if '@' in url_path:
+                    username, url_path = url_path.split('@', 1)
+                else:
+                    username = ""
+                # get the username from the warhorn_config file when it is not in the url
+                if username == "":
+                    username = get_attribute_value(repository, "username")
+                password = get_attribute_value(repository, "password")
+
+                # modify http/https URL to include username and password in it
+                # format: https://username:password@path/to/repo
+                if username != "" and password != "":
+                    username = urllib.quote_plus(username)
+                    password = urllib.quote_plus(password)
+                    url = url_type + "://" + username + ":" + password + '@' + url_path
 
             # url validation
             if url == "":


### PR DESCRIPTION
Added an option to provide username and password in warhorn config file to support cloning private repositories(applicable to http/https url types).

For http/https url types, given username and password will be added to the git url to support cloning repo at command line itself.

How to test: Clone private(http/https) driver/warriorspace/tools repo by providing username & password in corresponding block in warhorn config file. Sample config file and the combinations tested are in Jira ticket.