### PR TITLE
WAR-1813: Selenium: _make_browser() function got multiple values for keyword argument 'profile_dir'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,10 @@ install:
     fi
   - if [[ ${SELENIUM_3} = "yes" ]] && [[ ! -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
       pip install selenium==3.12 ;
-      wget https://github.com/mozilla/geckodriver/releases/download/v0.20.1/geckodriver-v0.20.1-linux64.tar.gz
-      tar -xvzf geckodriver-v0.20.1-linux64.tar.gz
-      chmod +x geckodriver
-      sudo mv geckodriver /usr/local/bin/
+      wget https://github.com/mozilla/geckodriver/releases/download/v0.20.1/geckodriver-v0.20.1-linux64.tar.gz;
+      tar -xvzf geckodriver-v0.20.1-linux64.tar.gz;
+      chmod +x geckodriver;
+      sudo mv geckodriver /usr/local/bin/;
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
         chrome: stable
     - sudo: required
       dist: trusty
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/testcases/selenium_tests/tc_selenium_headless.xml SELENIUM=yes SELENIUM_3=yes
+      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/testcases/selenium_tests/tc_selenium_headless.xml SELENIUM=yes SELENIUM_3=yes GECKODRIVER=yes
       addons:
         firefox: "60.0"
         chrome: stable
@@ -51,7 +51,9 @@ install:
       mv chromedriver ~/bin/chromedriver;
     fi
   - if [[ ${SELENIUM_3} = "yes" ]] && [[ ! -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
-      pip install selenium==3.12 ;
+      pip install selenium==3.8 ;
+    fi
+  - if [[ ${GECKODRIVER} = "yes" ]] && [[ ! -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
       wget https://github.com/mozilla/geckodriver/releases/download/v0.20.1/geckodriver-v0.20.1-linux64.tar.gz;
       tar -xvzf geckodriver-v0.20.1-linux64.tar.gz;
       chmod +x geckodriver;

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
       wget https://github.com/mozilla/geckodriver/releases/download/v0.20.1/geckodriver-v0.20.1-linux64.tar.gz;
       tar -xvzf geckodriver-v0.20.1-linux64.tar.gz;
       chmod +x geckodriver;
-      sudo mv geckodriver /usr/local/bin/;
+      sudo mv geckodriver ~/bin/geckodriver;
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       dist: trusty
       env: INSTALL=yes TESTFILE=./wftests/warrior_tests/testcases/selenium_tests/tc_selenium_headless.xml SELENIUM=yes SELENIUM_3=yes
       addons:
-        firefox: "60.0.1"
+        firefox: "60.0"
         chrome: stable
     - sudo: false
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       dist: trusty
       env: INSTALL=yes TESTFILE=./wftests/warrior_tests/testcases/selenium_tests/tc_selenium_headless.xml SELENIUM=yes SELENIUM_3=yes
       addons:
-        firefox: "46.0"
+        firefox: "60.0.1"
         chrome: stable
     - sudo: false
       dist: trusty
@@ -51,7 +51,11 @@ install:
       mv chromedriver ~/bin/chromedriver;
     fi
   - if [[ ${SELENIUM_3} = "yes" ]] && [[ ! -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
-      pip install selenium==3.8 ;
+      pip install selenium==3.12 ;
+      wget https://github.com/mozilla/geckodriver/releases/download/v0.20.1/geckodriver-v0.20.1-linux64.tar.gz
+      tar -xvzf geckodriver-v0.20.1-linux64.tar.gz
+      chmod +x geckodriver
+      sudo mv geckodriver /usr/local/bin/
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
       wget https://github.com/mozilla/geckodriver/releases/download/v0.20.1/geckodriver-v0.20.1-linux64.tar.gz;
       tar -xvzf geckodriver-v0.20.1-linux64.tar.gz;
       chmod +x geckodriver;
-      sudo mv geckodriver ~/bin/geckodriver;
+      mv geckodriver ~/bin/geckodriver;
     fi
 
 script:

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -225,8 +225,6 @@ class browser_actions(object):
             else:
                 output_dict[system_name+"_headless"] = True
                 output_dict["headless_display"] = True
-        else:
-            output_dict[system_name+"_headless"] = False
 
         for browser in browser_list:
             arguments = Utils.data_Utils.get_default_ecf_and_et(arguments, self.datafile, browser)

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -47,8 +47,9 @@ class browser_actions(object):
         self.elementlocator_obj = elementlocator_actions()
 
     def browser_launch(self, system_name, browser_name="all", type="firefox",
-                       url=None, ip=None, remote=None, element_config_file=None,
-                       element_tag=None, headless_mode=None):
+                       binary=None, gecko_path=None, gecko_log=None, proxy_ip=None,
+                       proxy_port=None, url=None, ip=None, remote=None, 
+                       element_config_file=None, element_tag=None, headless_mode=None):
         """
         The Keyword would launch a browser and Navigate to the url, if provided by the user.
 

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -47,7 +47,7 @@ class browser_actions(object):
         self.elementlocator_obj = elementlocator_actions()
 
     def browser_launch(self, system_name, browser_name="all", type="firefox",
-                       url=None, ip=None, remote=None, element_config_file=None, 
+                       url=None, ip=None, remote=None, element_config_file=None,
                        element_tag=None, headless_mode=None):
         """
         The Keyword would launch a browser and Navigate to the url, if provided by the user.
@@ -232,14 +232,14 @@ class browser_actions(object):
             arguments = Utils.data_Utils.get_default_ecf_and_et(arguments, self.datafile, browser)
             browser_optional_arg_keys = {"binary": None, "gecko_path": None, "proxy_ip": None, 
                                          "proxy_port": None, "gecko_log": None}
-            #Adding browser_optional_arg_keys to arguments to get corresponding values from datafile.
+            # Adding browser_optional_arg_keys to arguments to get corresponding values from datafile.
             arguments.update(browser_optional_arg_keys)
             browser_details = selenium_Utils.\
                               get_browser_details(browser, datafile=self.datafile, **arguments)
             if browser_details is not None:
                 # Call utils to launch correct type of browser
                 # Need to pass the binary, gecko_path, proxy_ip, proxy_port, gecko_log 
-                #  if specified in the datafile
+                # if specified in the datafile
                 browser_optional_args = {}
                 for arg in browser_optional_arg_keys:
                     if browser_details.get(arg) is not None:

--- a/warrior/Actions/SeleniumActions/browser_actions.py
+++ b/warrior/Actions/SeleniumActions/browser_actions.py
@@ -47,9 +47,8 @@ class browser_actions(object):
         self.elementlocator_obj = elementlocator_actions()
 
     def browser_launch(self, system_name, browser_name="all", type="firefox",
-                       binary=None, gecko_path=None, gecko_log=None, proxy_ip=None,
-                       proxy_port=None, url=None, ip=None, remote=None, 
-                       element_config_file=None, element_tag=None, headless_mode=None):
+                       url=None, ip=None, remote=None, element_config_file=None, 
+                       element_tag=None, headless_mode=None):
         """
         The Keyword would launch a browser and Navigate to the url, if provided by the user.
 
@@ -231,13 +230,16 @@ class browser_actions(object):
 
         for browser in browser_list:
             arguments = Utils.data_Utils.get_default_ecf_and_et(arguments, self.datafile, browser)
+            browser_optional_arg_keys = {"binary": None, "gecko_path": None, "proxy_ip": None, 
+                                         "proxy_port": None, "gecko_log": None}
+            #Adding browser_optional_arg_keys to arguments to get corresponding values from datafile.
+            arguments.update(browser_optional_arg_keys)
             browser_details = selenium_Utils.\
                               get_browser_details(browser, datafile=self.datafile, **arguments)
             if browser_details is not None:
                 # Call utils to launch correct type of browser
-                # Need to pass the binary, gecko_path, proxy_ip, proxy_port if specified
-                browser_optional_arg_keys = ["binary", "gecko_path",
-                                             "proxy_ip", "proxy_port", "gecko_log"]
+                # Need to pass the binary, gecko_path, proxy_ip, proxy_port, gecko_log 
+                #  if specified in the datafile
                 browser_optional_args = {}
                 for arg in browser_optional_arg_keys:
                     if browser_details.get(arg) is not None:

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -516,15 +516,16 @@ class BrowserManagement(object):
         """Create an instance of firefox browser"""
         binary = kwargs.get("binary", None)
         gecko_path = kwargs.get("gecko_path", None)
+        # gecko_log is the absolute path to save geckodriver log
+        gecko_log = kwargs.get("gecko_log", None)
         proxy_ip = kwargs.get("proxy_ip", None)
         proxy_port = kwargs.get("proxy_port", None)
         ff_profile = None
         # if firefox is being used with proxy, set the profile here
         if proxy_ip is not None and proxy_port is not None:
             ff_profile = self.set_firefox_proxy(profile_dir, proxy_ip, proxy_port)
-
         log_dir = get_object_from_datarepository("wt_logsdir") if \
-                  kwargs.get("log_path") in [None, False] else kwargs.get("log_path")
+                  gecko_log in [None, False] else gecko_log
         log_dir = os.path.join(log_dir, "gecko_"+kwargs.get("browser_name", "default")+".log")
 
         browser = None

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -24,7 +24,7 @@ from Framework.Utils.testcase_Utils import pNote
 from Framework.Utils.print_Utils import print_error, print_info, print_debug, print_exception,\
     print_warning
 from Framework.Utils.data_Utils import get_object_from_datarepository
-
+from Framework.Utils.file_Utils import fileExists
 
 try:
     from selenium import webdriver
@@ -540,6 +540,11 @@ class BrowserManagement(object):
                 # This is for internal testing needs...some https cert is not secure
                 # And firefox will need to know how to handle it
                 ff_capabilities['acceptInsecureCerts'] = True
+                
+                if not fileExists(str(binary)):
+                    print_warning("firefox binary '{}' does not exist, default "
+                                  "firefox will be used for execution.".format(binary))
+                    binary = None
 
                 # Force disable marionette, only needs in Selenium 3 with FF ver < 47
                 # Without these lines, selenium may encounter capability not found issue

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -442,7 +442,7 @@ class BrowserManagement(object):
             Use firefox binary to find out firefox version
             before launching firefox in selenium
         """
-        raw_version = ""
+        command = ""
         # If the platform is Linux,
         # If Binary - None: default binary is set as "firefox".
         # else the binary path passed through datafile is considered.
@@ -452,15 +452,15 @@ class BrowserManagement(object):
         if platform.system() in "Linux":
             if binary in [False, None]:
                 binary = "firefox"
-            raw_version = check_output([binary, "-v"]) 
+            command = [binary, "-v"]
         elif platform.system() in "Windows":
             if binary in [False, None]:
                 binary = self.ff_binary_object._default_windows_location()
             command = "%s -v | more" % (binary) 
-            raw_version = check_output(command)
         print_info("Platform: {0} Firefox binary path: {1}".format(platform.system(), binary))
         version = False
         try:
+            raw_version = check_output(command) 
             match = re.search(r"\d+\.\d+", raw_version)
             if match is not None:
                 version = LooseVersion(match.group(0))

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -522,8 +522,12 @@ class BrowserManagement(object):
         proxy_port = kwargs.get("proxy_port", None)
         ff_profile = None
         # if firefox is being used with proxy, set the profile here
+        # if firefox_proxy details are not given, set profile_dir
+        # as the ff_profile.
         if proxy_ip is not None and proxy_port is not None:
             ff_profile = self.set_firefox_proxy(profile_dir, proxy_ip, proxy_port)
+        else:
+            ff_profile = profile_dir
         log_dir = get_object_from_datarepository("wt_logsdir") if \
                   gecko_log in [None, False] else gecko_log
         log_dir = os.path.join(log_dir, "gecko_"+kwargs.get("browser_name", "default")+".log")

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -53,7 +53,8 @@ class BrowserManagement(object):
         """Open a browser session"""
 
         profile_dir = kwargs.get('profile_dir', None)
-
+        if 'profile_dir' in kwargs:
+            kwargs.pop('profile_dir')
         if webdriver_remote_url:
             print_debug("Opening browser '{0}' through remote server at '{1}'"\
                         .format(browser_name, webdriver_remote_url))

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -540,11 +540,15 @@ class BrowserManagement(object):
                 # This is for internal testing needs...some https cert is not secure
                 # And firefox will need to know how to handle it
                 ff_capabilities['acceptInsecureCerts'] = True
-                
-                if not fileExists(str(binary)):
-                    print_warning("firefox binary '{}' does not exist, default "
-                                  "firefox will be used for execution.".format(binary))
-                    binary = None
+
+                if binary not in [False, None]:
+                    if not fileExists(binary):
+                        print_warning("Given firefox binary '{}' does not exist, default "
+                                      "firefox will be used for execution.".format(binary))
+                        binary = None
+                else:
+                    print_info("No value given for firefox binary, default "
+                               "firefox will be used for execution.")
 
                 # Force disable marionette, only needs in Selenium 3 with FF ver < 47
                 # Without these lines, selenium may encounter capability not found issue

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -439,7 +439,7 @@ class BrowserManagement(object):
             Use firefox binary to find out firefox version
             before launching firefox in selenium
         """
-        if binary in [False, None, str(None)]:
+        if binary in [False, None]:
             binary = "firefox"
         version = False
         try:
@@ -552,7 +552,7 @@ class BrowserManagement(object):
                     # Gecko driver will only launch if FF version is 47 or above
                     optional_args["log_path"] = log_dir
 
-                ffbinary = FirefoxBinary(binary) if binary not in [None, str(None)] else None
+                ffbinary = FirefoxBinary(binary) if binary is not None else None
                 if gecko_path is not None:
                     optional_args["executable_path"] = gecko_path
                 browser = webdriver.Firefox(firefox_binary=ffbinary,

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -25,6 +25,7 @@ from Framework.Utils.print_Utils import print_error, print_info, print_debug, pr
     print_warning
 from Framework.Utils.data_Utils import get_object_from_datarepository
 from Framework.Utils.file_Utils import fileExists
+import platform
 
 try:
     from selenium import webdriver
@@ -47,6 +48,7 @@ class BrowserManagement(object):
         """Browser management constructor """
         self.current_browser = None
         self.current_window = None
+        self.ff_binary_object = FirefoxBinary()
 
     def open_browser(self, browser_name='firefox', webdriver_remote_url=False,
                      desired_capabilities=None, **kwargs):
@@ -439,11 +441,25 @@ class BrowserManagement(object):
             Use firefox binary to find out firefox version
             before launching firefox in selenium
         """
-        if binary in [False, None]:
-            binary = "firefox"
+        raw_version=""
+        # If the platform is Linux, 
+        # If Binary - None: default binary is set as "firefox".
+        # else the binary path passed through datafile is considered.
+        # If the platform is Windows, 
+        # If Binary - None: default binary is set to Program Files path.           
+        # else the binary path passed through datafile is considered.
+        if platform.system() in "Linux":
+            if binary in [False, None]:
+                binary = "firefox"
+            raw_version = check_output([binary, "-v"]) 
+        elif platform.system() in "Windows":
+            if binary in [False, None]:
+                binary=self.ff_binary_object._default_windows_location()
+            command = "%s -v | more" % (binary)    
+            raw_version = check_output(command)          
+        print_info("Platform: {0} Firefox binary path: {1}".format(platform.system(),binary))
         version = False
         try:
-            raw_version = check_output([binary, "-v"])
             match = re.search(r"\d+\.\d+", raw_version)
             if match is not None:
                 version = LooseVersion(match.group(0))

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -552,7 +552,7 @@ class BrowserManagement(object):
                     # Gecko driver will only launch if FF version is 47 or above
                     optional_args["log_path"] = log_dir
 
-                ffbinary = FirefoxBinary(binary) if binary is not None else None
+                ffbinary = FirefoxBinary(binary) if binary not in [None, str(None)] else None
                 if gecko_path is not None:
                     optional_args["executable_path"] = gecko_path
                 browser = webdriver.Firefox(firefox_binary=ffbinary,

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -11,12 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 
-""" selenium browser management library"""
 import os
 import re
 import traceback
 from time import sleep
 import urllib2
+import platform
 from subprocess import check_output, CalledProcessError
 from distutils.version import LooseVersion
 from Framework.Utils.datetime_utils import get_current_timestamp
@@ -25,7 +25,6 @@ from Framework.Utils.print_Utils import print_error, print_info, print_debug, pr
     print_warning
 from Framework.Utils.data_Utils import get_object_from_datarepository
 from Framework.Utils.file_Utils import fileExists
-import platform
 
 try:
     from selenium import webdriver
@@ -40,6 +39,8 @@ try:
             7: Keys.NUMPAD7, 8: Keys.NUMPAD8, 9: Keys.NUMPAD9}
 except ImportError as exception:
     print_exception(exception)
+
+""" selenium browser management library"""
 
 class BrowserManagement(object):
     """Browser management class"""
@@ -441,12 +442,12 @@ class BrowserManagement(object):
             Use firefox binary to find out firefox version
             before launching firefox in selenium
         """
-        raw_version=""
-        # If the platform is Linux, 
+        raw_version = ""
+        # If the platform is Linux,
         # If Binary - None: default binary is set as "firefox".
         # else the binary path passed through datafile is considered.
-        # If the platform is Windows, 
-        # If Binary - None: default binary is set to Program Files path.           
+        # If the platform is Windows,
+        # If Binary - None: default binary is set to Program Files path.
         # else the binary path passed through datafile is considered.
         if platform.system() in "Linux":
             if binary in [False, None]:
@@ -454,10 +455,10 @@ class BrowserManagement(object):
             raw_version = check_output([binary, "-v"]) 
         elif platform.system() in "Windows":
             if binary in [False, None]:
-                binary=self.ff_binary_object._default_windows_location()
-            command = "%s -v | more" % (binary)    
-            raw_version = check_output(command)          
-        print_info("Platform: {0} Firefox binary path: {1}".format(platform.system(),binary))
+                binary = self.ff_binary_object._default_windows_location()
+            command = "%s -v | more" % (binary) 
+            raw_version = check_output(command)
+        print_info("Platform: {0} Firefox binary path: {1}".format(platform.system(), binary))
         version = False
         try:
             match = re.search(r"\d+\.\d+", raw_version)

--- a/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
+++ b/warrior/Framework/ClassUtils/WSelenium/browser_mgmt.py
@@ -439,7 +439,7 @@ class BrowserManagement(object):
             Use firefox binary to find out firefox version
             before launching firefox in selenium
         """
-        if binary in [False, None]:
+        if binary in [False, None, str(None)]:
             binary = "firefox"
         version = False
         try:


### PR DESCRIPTION
Issue:
-------
_makebrowser method has profile_dir as well as **kw_args. However, profile_dir value is obtained from kw_args in previous step. Due to this, now there are two profile_dir attributes in __make_browser function call. This results in above failure.
TypeError: _make_browser() got multiple values for keyword argument 'profile_dir'

**Fix:**  Added logic to remove the profile_dir from kwargs, if exists.

Other Issues fixed along with this are:
Issue-1: 
-------
Binary, gecko_path, gecko_log, proxy_ip, proxy_port values given through datafile where not being read in browser_actions.

**Fix:**  Appended the default argument dict with these attributes. Now, the values are being read from the datafile.

Issue-2:
--------
gecko-log specified in datafile was not being read correctly in browser_management file. 

**Fix**: Updated the file to log the driver info in the path specified in datafile.

Issue-3:
--------
If empty/invalid binary path is passed in the datafile,  inappropriate error message is thrown.

**Fix:**  Provided appropriate error message if empty/invalid binary path is passed in the datafile.

Issue-4:
--------
ff_profile does not get set, if proxy_ip/port are None.

**Fix:**  Added else block to set ff_profile as profile_dir, in case proxy_ip/port are None.

Issue-5:
--------
get_firefox_version() keyword has a version check command specific to Linux only. Hence, execution in windows environment fails.

**Fix:** Added platform specific check in  get_firefox_version() keyword, such that, it builds the firefox version command based on the platform used.

travis.yml file update:
-----------------------
For Selenium 3, it makes sense to add tests with latest selenium version, latest geckodriver and a latest stable firefox version.
Hence,  updated the file.

Please find logs attached in the ticket: WAR-1813