### PR TITLE
hotfix-3.9.1 to develop

### DIFF
--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,5 +1,5 @@
 Release: Ninja
-Version: warrior-3.9.0
+Version: warrior-3.9.1
 
 ===================
 1: Release details
@@ -19,7 +19,7 @@ This is release Ninja of Warrior Test Automation Framework
 ==================
 2. Version Details
 ==================
-You are on Release Ninja, Version warrior-3.9.0 of Warrior Framework.
+You are on Release Ninja, Version warrior-3.9.1 of Warrior Framework.
 Procedure to get a specific version is available in section-3 of this document.
 
 
@@ -28,26 +28,10 @@ Procedure to get a specific version is available in section-3 of this document.
 2.1. Change log for this release
 +++++++++++++++++++++++++++++++++
 
--------------
-New Features:
--------------
-[WAR-1669] - User confused on the amount of time Warrior waits for a send command by test data
-[WAR-1675] - As a user, I need an option to set pseudo-terminal dimensions in connect keywords
-[WAR-1718] - HTML Result summary attachment is huge - Need to be Zipped and compressed format
-[WAR-1756] - Improve pylint score for rest_actions.py
-[WAR-1799] - Update pj_exec_summary to better test execution summary print
-[WAR-1809] - As a user, I need an option to store arithmetic expression result in the data_repo using verify_arith_exp kw
-
 ---------
 Bugfixes:
 ---------
-[WAR-1358] - print_warning creates two print 1. -W- "Warning 2. -I- Information
-[WAR-1381] - Not getting executed for y number of systems specified in ID file (when ID is passed using CLI command)
-[WAR-1676] - Event Notification not validated for equipment events using waitfor_subscription
-[WAR-1716] - Project execution mail subject reflected as NONE eventhough the project is passed
-[WAR-1802] - The keyword 'send_commands_by_testdata_title_rownum' does not store the response into the data repository
-[WAR-1813] - Selenium: _make_browser() function got multiple values for keyword argument 'profile_dir'
-[WAR-1843] - verify_response keyword in rest failing even for correct jsonpath
+[WAR-1911] - Revert changes made to set default value for env in pexpect_spawn_with_env method
 
 
 =================================================

--- a/version.txt
+++ b/version.txt
@@ -1,5 +1,5 @@
 Name        : warriorframework                       
-Version     : warrior-3.9.0
+Version     : warrior-3.9.1
 Release     : Ninja
-Build Date  : Mon Jun 18 01:36:00 CDT 2018
+Build Date  : Wed Jun 20 01:39:00 CDT 2018
 Size        : 56M

--- a/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
+++ b/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
@@ -860,26 +860,23 @@ class WarriorCli(object):
                                env=None, pty_dimensions=None):
         """ spawn a pexpect object with environment & pty_dimensions variables """
 
-        if not(str(escape).lower() == "yes" or str(escape).lower() == "true"):
+        if env is None:
             env = {}
 
-        sendPtyDimensions = False
+        kwargs = {'timeout': int(timeout)}
+
+        if str(escape).lower() == "yes" or str(escape).lower() == "true":
+            kwargs['env'] = env
+
         if pty_dimensions is not None:
-            # 'dimensions' argument is supported in pexpect version 4.0 and above
-            if LooseVersion(pexpect_obj.__version__) >= LooseVersion('4.0'):
-                sendPtyDimensions = True
-            else:
+            if LooseVersion(pexpect_obj.__version__) < LooseVersion('4.0'):
                 print_warning("Setting pseudo-terminal dimensions is not supported in "
                               "pexpect versions less than 4.0(installed pexpect "
-                              "version: {}), 'dimensions' value will be default "
-                              "to None".format(pexpect_obj.__version__))
+                              "version: {})".format(pexpect_obj.__version__))
+            else:
+                kwargs['dimensions'] = pty_dimensions
 
-        if sendPtyDimensions is True:
-            child = pexpect_obj.spawn(command, timeout=int(timeout), env=env,
-                                      dimensions=pty_dimensions)
-        else:
-            child = pexpect_obj.spawn(command, timeout=int(timeout), env=env)
-
+        child = pexpect_obj.spawn(command, **kwargs)
         return child
 
     @staticmethod


### PR DESCRIPTION
Fix for WAR-1911: Revert changes made to set default value for env in pexpect_spawn_with_env method
Modified version and release notes
More details in WAR-19111