### PR TITLE
WAR-1116: Remove 'cse script execution' option from warriorframework repo

### DIFF
--- a/warrior/Framework/Utils/data_Utils.py
+++ b/warrior/Framework/Utils/data_Utils.py
@@ -1490,29 +1490,6 @@ def verify_inorder_cmd_response(match_list, verify_list, system, command,
     return status
 
 
-def get_cse_script_args_string(datafile, system_name):
-    """Form the argument string for the CSE script from the arguments
-    provided in datafile"""
-    args_string = False
-    tag_value = get_child_tag_value_list(datafile, system_name, ['Arguments'])
-
-    if tag_value is not False:
-        tag_list = tag_value[0]
-        value_list = tag_value[1]
-        script_args_list = []
-        x = len(tag_list)
-        for x in range(0, x):
-            attr = '-' + tag_list[x]
-            value = value_list[x]
-            script_args_list.append(attr)
-            if value is None:
-                value = ''
-            script_args_list.append(value)
-        args_string = ' '.join(script_args_list)
-
-        return args_string
-
-
 def evaluate_tc_argument_value(element):
     """ Splits the value of the attribute value in the argument tag in the TC
     """

--- a/warrior/Warrior
+++ b/warrior/Warrior
@@ -46,7 +46,6 @@ except:
 This is the Warrior executable
 """
 
-CSE_EXEC = False
 AUTO_DEFECTS = False
 IRON_CLAW = False
 VERSION = False
@@ -79,7 +78,7 @@ def update_jira_by_id(jiraproj, jiraid, exec_dir, status):
     else:
         print_info("jiraid not provided, will not update jira issue")
 
-def main(parameter_list, a_defects, cse_execution, iron_claw, jiraproj, overwrite, jiraid, dbsystem, headless):
+def main(parameter_list, a_defects, iron_claw, jiraproj, overwrite, jiraid, dbsystem, headless):
     """Parses the input parameters (i.e. sys.argv)
         If the input parameter is an xml file:
             - check if file exists, if exists
@@ -96,9 +95,7 @@ def main(parameter_list, a_defects, cse_execution, iron_claw, jiraproj, overwrit
     """
     status = False
 
-    if cse_execution:
-        status = cse_command_line_exec()
-    elif iron_claw:
+    if iron_claw:
         status = ironclaw_driver.main(parameter_list)
     else:
         abs_cur_dir = os.path.abspath(os.curdir)
@@ -169,14 +166,14 @@ def main(parameter_list, a_defects, cse_execution, iron_claw, jiraproj, overwrit
 
 if __name__ == '__main__':
 
-    FILEPATH, AUTO_DEFECTS, version, CSE_EXEC, IRON_CLAW, JIRAPROJ, \
+    FILEPATH, AUTO_DEFECTS, version, IRON_CLAW, JIRAPROJ, \
     OVERWRITE, JIRAID, DBSYSTEM, HEADLESS = warrior_cli_driver.main(sys.argv[1:])
     if version:
         framework_detail.warrior_framework_details()
         sys.exit(0)
-    if not CSE_EXEC and len(FILEPATH) == 0:
+    if len(FILEPATH) == 0:
         print_error("Provide atleast one xml file to execute")
-    status = main(FILEPATH, AUTO_DEFECTS, CSE_EXEC, IRON_CLAW,
+    status = main(FILEPATH, AUTO_DEFECTS, IRON_CLAW,
                   JIRAPROJ, OVERWRITE, JIRAID, DBSYSTEM, HEADLESS)
     status = {"true": True, "pass": True, "ran": "RAN"}.get(str(status).lower())
     if status is True or status == "RAN":

--- a/warrior/WarriorCore/Classes/war_cli_class.py
+++ b/warrior/WarriorCore/Classes/war_cli_class.py
@@ -255,10 +255,6 @@ class WarriorCliClass(object):
                             "Multiple files of different type can be provided "\
                             "(separated by a space)")
 
-        # Trigger cse execution
-        parser.add_argument('-cse', action='store_true', default=False,
-                            help=':cse: Run CSE execution from Warrior command line')
-
         # Run Ironclaw tool
         parser.add_argument('-ironclaw', action='store_true', default=False,
                             help=":ironclaw: Run Warrior's IronClaw tool. "

--- a/warrior/WarriorCore/warrior_cli_driver.py
+++ b/warrior/WarriorCore/warrior_cli_driver.py
@@ -215,7 +215,7 @@ def decide_action(w_cli_obj, namespace):
 
     # print filepath
     return (filepath, namespace.ad, namespace.version,
-            namespace.cse, namespace.ironclaw, namespace.jiraproj, overwrite,
+            namespace.ironclaw, namespace.jiraproj, overwrite,
             namespace.jiraid, namespace.dbsystem, namespace.headless)
 
 


### PR DESCRIPTION
Issue:
------
cse script execution is not supported in warriorframework repo(OSS) as it is internal to FNC, action file has been removed already but the Warrior executable(function call) & parser methods still has some cse code which needs to be removed. cse option should not be listed in warrior help as well.

Fix:
---
Removed all the cse related code from warriorframework.
Removed from help options as well.

Related logs are attached in JIRA: WAR-1116