### PR TITLE
WAR-1348: Modularise Runmode across Warrior. As a user, I want same tags for Runmode whereever i use Runmode functions such as RMT, RUP & RUF

### DIFF
--- a/warrior/WarriorCore/common_execution_utils.py
+++ b/warrior/WarriorCore/common_execution_utils.py
@@ -115,7 +115,7 @@ def get_step_list(filepath, step_tag, sub_step_tag):
             step_list_with_rmt_retry = append_step_list(step_list_with_rmt_retry, step,
                                                         value, go_next, mode="runmode",
                                                         tag="value")
-        if retry_type is not None and value > 0:
+        if retry_type is not None and retry_value > 0:
             go_next = len(step_list_with_rmt_retry) + retry_value + 1
             if runmode is not None:
                 get_runmode = step.find('runmode')

--- a/warrior/WarriorCore/common_execution_utils.py
+++ b/warrior/WarriorCore/common_execution_utils.py
@@ -11,8 +11,122 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 
-"""Module that contains common utilities required for execution """
-from Framework.Utils.print_Utils import print_warning
+import copy
+import glob
+import os
+
+from Framework.Utils.print_Utils import print_warning, print_info
+import Framework.Utils as Utils
+
+""" Module that contains common utilities required for execution """
+
+
+def append_step_list(step_list, step, value, go_next, mode, tag):
+    """from step_list, append the number of times a step needs to be repeated
+    if runmode or retry is present
+
+    :Arguments:
+        step_list = Ordered list of steps to be executed
+        step = Current step
+        value =  attempts in runmode/retry
+        go_next = value of the real next step
+        mode = runmode or retry
+        tag = In runmode it is value, in retry it is count
+
+    :Return:
+        step_list = New step list formed by appending the replicated steps
+    """
+    for i in range(0, value):
+        copy_step = copy.deepcopy(step)
+        copy_step.find(mode).set(tag, go_next)
+        copy_step.find(mode).set("attempt", i + 1)
+        step_list.append(copy_step)
+    return step_list
+
+
+def get_step_list(filepath, step_tag, sub_step_tag):
+    """
+    Takes the location of Testcase/Suite/Project file as input
+    Returns a list of all the step/testcase/testsuite elements
+    present in the file.
+
+    :Arguments:
+        1. filepath     = full path of the Testcase/suite/project xml file
+        2. step_tag     = xml tag for group of step in the file
+        3. sub_step_tag = xml tag for each step in the file
+    """
+    step_list_with_rmt_retry = []
+    root = Utils.xml_Utils.getRoot(filepath)
+    steps = root.find(step_tag)
+    if steps is None:
+        print_warning("The file: '{0}' has no {1} to be executed"
+                      .format(filepath, step_tag))
+    step_list = steps.findall(sub_step_tag)
+    if root.tag == 'Project' or root.tag == 'TestSuite':
+        step_list = []
+        orig_step_list = steps.findall(sub_step_tag)
+        for orig_step in orig_step_list:
+            orig_step_path = orig_step.find('path').text
+            if '*' not in orig_step_path:
+                step_list.append(orig_step)
+            # When the file path has asterisk(*), get the Warrior XML testcase/testsuite
+            # files matching the given pattern
+            else:
+                orig_step_abspath = Utils.file_Utils.getAbsPath(
+                    orig_step_path, os.path.dirname(filepath))
+                print_info("Provided {0} path: '{1}' has asterisk(*) in "
+                           "it. All the Warrior XML files matching "
+                           "the given pattern will be executed."
+                           .format(sub_step_tag, orig_step_abspath))
+                # Get all the files matching the pattern and sort them by name
+                all_files = sorted(glob.glob(orig_step_abspath))
+                # Get XML files
+                xml_files = [fl for fl in all_files if fl.endswith('.xml')]
+                step_files = []
+                # Get Warrior testcase/testsuite XML files
+                for xml_file in xml_files:
+                    root = Utils.xml_Utils.getRoot(xml_file)
+                    if root.tag.upper() == sub_step_tag.upper():
+                        step_files.append(xml_file)
+                # Copy the XML object and set the filepath as path value for
+                # all the files matching the pattern
+                if step_files:
+                    for step_file in step_files:
+                        new_step = copy.deepcopy(orig_step)
+                        new_step.find('path').text = step_file
+                        step_list.append(new_step)
+                        print_info("{0}: '{1}' added to the execution "
+                                   "list ".format(sub_step_tag, step_file))
+                else:
+                    print_warning("Asterisk(*) pattern match failed for '{}' due "
+                                  "to at least one of the following reasons:\n"
+                                  "1. No files matched the given pattern\n"
+                                  "2. Invalid testcase path is given\n"
+                                  "3. No testcase XMLs are available\n"
+                                  "Given path will be used for the Warrior "
+                                  "execution.".format(orig_step_abspath))
+                    step_list.append(orig_step)
+    # iterate all steps to get the runmode and retry details
+    for _, step in enumerate(step_list):
+        runmode, value, _ = get_runmode_from_xmlfile(step)
+        retry_type, _, _, retry_value, _ = get_retry_from_xmlfile(step)
+        if runmode is not None and value > 0:
+            go_next = len(step_list_with_rmt_retry) + value + 1
+            print "#####go_next", go_next
+            step_list_with_rmt_retry = append_step_list(step_list_with_rmt_retry, step,
+                                                        value, go_next, mode="runmode",
+                                                        tag="value")
+        if retry_type is not None and value > 0:
+            go_next = len(step_list_with_rmt_retry) + retry_value + 1
+            if runmode is not None:
+                get_runmode = step.find('runmode')
+                step.remove(get_runmode)
+            step_list_with_rmt_retry = append_step_list(step_list_with_rmt_retry, step,
+                                                        retry_value, go_next, mode="retry",
+                                                        tag="count")
+        if retry_type is None and runmode is None:
+            step_list_with_rmt_retry.append(step)
+    return step_list_with_rmt_retry
 
 
 def get_runmode_from_xmlfile(element):
@@ -53,7 +167,6 @@ def get_runmode_from_xmlfile(element):
                               "and these values can not be combined with other"
                               " values".format(rt_type))
                 return (None, 1, None)
-
             try:
                 rt_value = int(rt_value)
 
@@ -70,6 +183,7 @@ def get_runmode_from_xmlfile(element):
                 rt_value = 1
 
     return (rt_type, rt_value, runmode_timer)
+
 
 def get_retry_from_xmlfile(element):
     """Get 'retry' tag and its values from the testcase step.
@@ -88,8 +202,8 @@ def get_retry_from_xmlfile(element):
         retry_value = retry_tag.get('count')
         retry_interval = retry_tag.get('interval')
         if not retry_type in ['if', 'if not']:
-            print_warning("Unsupported value '{0}' provided for 'retry:"\
-                          "type' tag. Supported values : 'if, if not' "\
+            print_warning("Unsupported value '{0}' provided for 'retry:"
+                          "type' tag. Supported values : 'if, if not' "
                           .format(retry_type))
             return (None, None, None, 5, 5)
         if (retry_cond is None) or (retry_cond_value is None):
@@ -100,14 +214,14 @@ def get_retry_from_xmlfile(element):
         retry_value = str(retry_value)
         if retry_interval.isdigit() is False:
             retry_interval = 5
-            print_warning("The value provided for "\
-                          "retry:retry_interval is not valid, "\
+            print_warning("The value provided for "
+                          "retry:retry_interval is not valid, "
                           "using default value 5 for execution")
         retry_interval = int(retry_interval)
         if retry_value.isdigit() is False:
             retry_value = 5
-            print_warning("The value provided for "\
-                          "retry:retry_value is not valid, "\
+            print_warning("The value provided for "
+                          "retry:retry_value is not valid, "
                           "using default value 5 for execution")
         retry_value = int(retry_value)
     return (retry_type, retry_cond, retry_cond_value, retry_value, retry_interval)

--- a/warrior/WarriorCore/common_execution_utils.py
+++ b/warrior/WarriorCore/common_execution_utils.py
@@ -112,7 +112,6 @@ def get_step_list(filepath, step_tag, sub_step_tag):
         retry_type, _, _, retry_value, _ = get_retry_from_xmlfile(step)
         if runmode is not None and value > 0:
             go_next = len(step_list_with_rmt_retry) + value + 1
-            print "#####go_next", go_next
             step_list_with_rmt_retry = append_step_list(step_list_with_rmt_retry, step,
                                                         value, go_next, mode="runmode",
                                                         tag="value")

--- a/warrior/WarriorCore/project_driver.py
+++ b/warrior/WarriorCore/project_driver.py
@@ -94,89 +94,6 @@ def get_project_details(project_filepath, res_startdir, logs_startdir, data_repo
     return project_repository
 
 
-def get_testsuite_list(project_filepath):
-    """Takes the location of any Project.xml file as input
-    Returns a list of all the Testsuite elements present in the Project"""
-
-    testsuite_list = []
-    root = Utils.xml_Utils.getRoot(project_filepath)
-    testsuites = root.find('Testsuites')
-    if testsuites is None:
-        print_info('Testsuite is empty: tag <Testsuites> not "\
-                   "found in the input file ')
-    else:
-        new_testsuite_list = []
-        orig_testsuite_list = testsuites.findall('Testsuite')
-        for orig_ts in orig_testsuite_list:
-            orig_ts_path = orig_ts.find('path').text
-            if '*' not in orig_ts_path:
-                new_testsuite_list.append(orig_ts)
-            # When the file path has asterisk(*), get the Warrior XML testsuite
-            # files matching the given pattern
-            else:
-                orig_ts_abspath = Utils.file_Utils.getAbsPath(
-                    orig_ts_path, os.path.dirname(project_filepath))
-                print_info("Provided testsuite path: '{}' has asterisk(*) in "
-                           "it. All the Warrior testsuite XML files matching "
-                           "the given pattern will be executed.".format(orig_ts_abspath))
-                # Get all the files matching the pattern and sort them by name
-                all_files = sorted(glob.glob(orig_ts_abspath))
-                # Get XML files
-                xml_files = [fl for fl in all_files if fl.endswith('.xml')]
-                ts_files = []
-                # Get Warrior testsuite XML files
-                for xml_file in xml_files:
-                    root = Utils.xml_Utils.getRoot(xml_file)
-                    if root.tag.upper() == "TESTSUITE":
-                        ts_files.append(xml_file)
-                # Copy the XML object and set the filepath as path value for
-                # all the files matching the pattern
-                if ts_files:
-                    for ts_file in ts_files:
-                        new_ts = copy.deepcopy(orig_ts)
-                        new_ts.find('path').text = ts_file
-                        new_testsuite_list.append(new_ts)
-                        print_info("Testsuite: '{}' added to the execution "
-                                   "list ".format(ts_file))
-                else:
-                    print_warning("Asterisk(*) pattern match failed for '{}' due "
-                                  "to at least one of the following reasons:\n"
-                                  "1. No files matched the given pattern\n"
-                                  "2. Invalid testsuite path is given\n"
-                                  "3. No testsuite XMLs are available\n"
-                                  "Given path will be used for the Warrior "
-                                  "execution.".format(orig_ts_abspath))
-                    new_testsuite_list.append(orig_ts)
-
-        for ts in new_testsuite_list:
-            runmode, value, _ = common_execution_utils.\
-                get_runmode_from_xmlfile(ts)
-            retry_type, _, _, retry_value, _ = common_execution_utils.\
-                get_retry_from_xmlfile(ts)
-            if runmode is not None and value > 0:
-                # more than one suite in suite list, insert new suite
-                go_next = len(testsuite_list) + value + 1
-                for i in range(0, value):
-                    copy_ts = copy.deepcopy(ts)
-                    copy_ts.find("runmode").set("value", go_next)
-                    copy_ts.find("runmode").set("attempt", i+1)
-                    testsuite_list.append(copy_ts)
-            if retry_type is not None and retry_value > 0:
-                if len(new_testsuite_list) > 1:
-                    go_next = len(testsuite_list) + retry_value + 1
-                    if runmode is not None:
-                        get_runmode = ts.find('runmode')
-                        ts.remove(get_runmode)
-                    for i in range(0, retry_value):
-                        copy_ts = copy.deepcopy(ts)
-                        copy_ts.find("retry").set("count", go_next)
-                        copy_ts.find("retry").set("attempt", i+1)
-                        testsuite_list.append(copy_ts)
-            if retry_type is None and runmode is None:
-                testsuite_list.append(ts)
-        return testsuite_list
-
-
 def execute_project(project_filepath, auto_defects, jiraproj, res_startdir, logs_startdir,
                     data_repository):
     """
@@ -201,7 +118,8 @@ def execute_project(project_filepath, auto_defects, jiraproj, res_startdir, logs
     project_repository = get_project_details(project_filepath, res_startdir, logs_startdir,
                                              data_repository)
     project_repository['project_title'] = project_title
-    testsuite_list = get_testsuite_list(project_filepath)
+    testsuite_list = common_execution_utils.get_step_list(project_filepath,
+                                                          "Testsuites", "Testsuite")
     # Prints the path of result summary file at the beginning of execution
     if data_repository['war_file_type'] == "Project":
         filename = os.path.basename(project_filepath)

--- a/warrior/WarriorCore/sequential_testcase_driver.py
+++ b/warrior/WarriorCore/sequential_testcase_driver.py
@@ -266,7 +266,7 @@ def execute_sequential_testcases(testcase_list, suite_repository,
                 testsuite_utils.update_tc_duration(str(tc_duration))
                 # if runmode is 'rup' & tc_status is True, skip the repeated
                 # execution of same testcase and move to next actual testcase
-                if runmode == "rup":
+                if runmode.upper() == "RUP":
                     goto_tc = str(value)
             elif tc_status == 'ERROR' or tc_status == 'EXCEPTION':
                 errors += 1
@@ -304,7 +304,7 @@ def execute_sequential_testcases(testcase_list, suite_repository,
                     goto_tc = False
                 # if runmode is 'ruf' & tc_status is False, skip the repeated
                 # execution of same testcase and move to next actual testcase
-                if not goto_tc and runmode == "ruf":
+                if not goto_tc and runmode.upper() == "RUF":
                     goto_tc = str(value)
         elif retry_type is not None:
             if retry_type.upper() == 'IF':

--- a/warrior/WarriorCore/sequential_testsuite_driver.py
+++ b/warrior/WarriorCore/sequential_testsuite_driver.py
@@ -163,12 +163,12 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
                 print_info("runmode attempt: {0}".format(testsuite.find("runmode").get("attempt")))
             # if runmode is 'ruf' & step_status is False, skip the repeated
             # execution of same TC step and move to next actual step
-            if not project_error_value and runmode == "RUF" and\
+            if not project_error_value and runmode.upper() == "RUF" and\
                     testsuite_status is False:
                 goto_testsuite = str(value)
             # if runmode is 'rup' & step_status is True, skip the repeated
             # execution of same TC step and move to next actual step
-            elif runmode == "RUP" and testsuite_status is True:
+            elif runmode.upper() == "RUP" and testsuite_status is True:
                 goto_testsuite = str(value)
         elif retry_type is not None:
             if testsuite.find("retry") is not None and\

--- a/warrior/WarriorCore/testcase_driver.py
+++ b/warrior/WarriorCore/testcase_driver.py
@@ -214,48 +214,6 @@ def junit_requirements(testcase_filepath, tc_junit_object, timestamp):
             tc_junit_object.add_requirement(req_id, timestamp)
 
 
-def get_steps_list(testcase_filepath):
-    """Takes the location of any Testcase xml file as input
-    Returns a list of all the step elements present in the Testcase
-
-    :Arguments:
-        1. testcase_filepath    = full path of the Testcase xml file
-    """
-    step_list = []
-    root = Utils.xml_Utils.getRoot(testcase_filepath)
-    Steps = root.find('Steps')
-    if Steps is None:
-        print_warning("Case: '{}' has no Steps/Keywords "
-                      "to be executed".format(testcase_filepath))
-    else:
-        step_list = []
-        new_step_list = Steps.findall('step')
-        # execute step multiple times
-        for _, step in enumerate(new_step_list):
-            runmode, value, _ = common_execution_utils.get_runmode_from_xmlfile(step)
-            retry_type, _, _, retry_value, _ = common_execution_utils.get_retry_from_xmlfile(step)
-            if runmode is not None and value > 0:
-                go_next = len(step_list) + value + 1
-                for i in range(0, value):
-                    copy_step = copy.deepcopy(step)
-                    copy_step.find("runmode").set("value", go_next)
-                    copy_step.find("runmode").set("attempt", i+1)
-                    step_list.append(copy_step)
-            if retry_type is not None and retry_value > 0:
-                go_next = len(step_list) + retry_value + 1
-                if runmode is not None:
-                    get_runmode = step.find('runmode')
-                    step.remove(get_runmode)
-                for i in range(0, retry_value):
-                    copy_step = copy.deepcopy(step)
-                    copy_step.find("retry").set("count", go_next)
-                    copy_step.find("retry").set("attempt", i+1)
-                    step_list.append(copy_step)
-            if retry_type is None and runmode is None:
-                step_list.append(step)
-        return step_list
-
-
 def compute_testcase_status(step_status, tc_status):
     """Compute the status of the testcase based on the step_status and the impact value of the step
 
@@ -492,7 +450,8 @@ def execute_testcase(testcase_filepath, data_repository, tc_context,
         html_filepath = os.path.join(data_repository['wt_resultsdir'],
                                      Utils.file_Utils.getNameOnly(filename)) + '.html'
         print_info("HTML result file: {0}".format(html_filepath))
-    step_list = get_steps_list(testcase_filepath)
+    step_list = common_execution_utils.get_step_list(testcase_filepath,
+                                                     "Steps", "step")
 
     tc_state = Utils.xml_Utils.getChildTextbyParentTag(testcase_filepath,
                                                        'Details', 'State')

--- a/warrior/WarriorCore/testcase_steps_execution.py
+++ b/warrior/WarriorCore/testcase_steps_execution.py
@@ -210,11 +210,11 @@ class TestCaseStepsExecutionClass(object):
             wait_for_timeout(runmode_timer)
         # if runmode is 'ruf' & step_status is False, skip the repeated
         # execution of same TC step and move to next actual step
-        elif runmode == "RUF" and step_status is False:
+        elif runmode.upper() == "RUF" and step_status is False:
             self.go_to_step_number = str(value)
         # if runmode is 'rup' & step_status is True, skip the repeated
         # execution of same TC step and move to next actual step
-        elif runmode == "RUP" and step_status is True:
+        elif runmode.upper() == "RUP" and step_status is True:
             self.go_to_step_number = str(value)
         else:
             if step_status is False or str(step_status).upper() in ["ERROR", "EXCEPTION"]:

--- a/warrior/WarriorCore/testsuite_driver.py
+++ b/warrior/WarriorCore/testsuite_driver.py
@@ -145,106 +145,6 @@ def report_suite_requirements(suite_repository, testsuite_filepath):
             ts_junit_object.add_requirement(req_id, suite_repository["wt_ts_timestamp"])
 
 
-def get_testcase_list(testsuite_filepath):
-    """Takes the location of any Testsuite xml file as input
-    Returns a list of all the Tescase elements present in the Testsuite
-
-    Arguments:
-    1. testsuite_filepath    = full path of the Testsuite xml file
-    """
-
-    testcase_list = []
-    root = Utils.xml_Utils.getRoot(testsuite_filepath)
-    testcases = root.find('Testcases')
-    if testcases is None:
-        print_info('Testsuite is empty: tag <Testcases> not found in the input Testsuite xml file ')
-    else:
-        new_testcase_list = []
-        orig_testcase_list = testcases.findall('Testcase')
-        for orig_tc in orig_testcase_list:
-            orig_tc_path = orig_tc.find('path').text
-            if '*' not in orig_tc_path:
-                new_testcase_list.append(orig_tc)
-            # When the file path has asterisk(*), get the Warrior XML testcase
-            # files matching the given pattern
-            else:
-                orig_tc_abspath = Utils.file_Utils.getAbsPath(
-                    orig_tc_path, os.path.dirname(testsuite_filepath))
-                print_info("Provided testcase path: '{}' has asterisk(*) in "
-                           "it. All the Warrior testcase XML files matching "
-                           "the given pattern will be executed.".format(orig_tc_abspath))
-                # Get all the files matching the pattern and sort them by name
-                all_files = sorted(glob.glob(orig_tc_abspath))
-                # Get XML files
-                xml_files = [fl for fl in all_files if fl.endswith('.xml')]
-                tc_files = []
-                # Get Warrior testcase XML files
-                for xml_file in xml_files:
-                    root = Utils.xml_Utils.getRoot(xml_file)
-                    if root.tag.upper() == "TESTCASE":
-                        tc_files.append(xml_file)
-                # Copy the XML object and set the filepath as path value for
-                # all the files matching the pattern
-                if tc_files:
-                    for tc_file in tc_files:
-                        new_tc = copy.deepcopy(orig_tc)
-                        new_tc.find('path').text = tc_file
-                        new_testcase_list.append(new_tc)
-                        print_info("Testcase: '{}' added to the execution "
-                                   "list ".format(tc_file))
-                else:
-                    print_warning("Asterisk(*) pattern match failed for '{}' due "
-                                  "to at least one of the following reasons:\n"
-                                  "1. No files matched the given pattern\n"
-                                  "2. Invalid testcase path is given\n"
-                                  "3. No testcase XMLs are available\n"
-                                  "Given path will be used for the Warrior "
-                                  "execution.".format(orig_tc_abspath))
-                    new_testcase_list.append(orig_tc)
-
-        # execute tc multiple times
-        for tc in new_testcase_list:
-            runmode, value, _ = common_execution_utils.get_runmode_from_xmlfile(tc)
-            retry_type, _, _, retry_value, _ = common_execution_utils.get_retry_from_xmlfile(tc)
-            if runmode is not None and value > 0:
-                # more than one step in step list, insert new step
-                if len(new_testcase_list) > 0:
-                    go_next = len(testcase_list) + value + 1
-                    for i in range(0, value):
-                        copy_tc = copy.deepcopy(tc)
-                        copy_tc.find("runmode").set("value", go_next)
-                        copy_tc.find("runmode").set("attempt", i+1)
-                        testcase_list.append(copy_tc)
-                # only one step in step list, append new step
-                else:
-                    for i in range(0, value):
-                        copy_tc = copy.deepcopy(tc)
-                        copy_tc.find("runmode").set("attempt", i+1)
-                        testcase_list.append(tc)
-            if retry_type is not None and retry_value > 0:
-                if len(new_testcase_list) > 1:
-                    go_next = len(testcase_list) + retry_value + 1
-                    if runmode is not None:
-                        get_runmode = tc.find('runmode')
-                        tc.remove(get_runmode)
-                    for i in range(0, retry_value):
-                        copy_tc = copy.deepcopy(tc)
-                        copy_tc.find("retry").set("count", go_next)
-                        copy_tc.find("retry").set("attempt", i+1)
-                        testcase_list.append(copy_tc)
-                else:
-                    if runmode is not None:
-                        get_runmode = tc.find('runmode')
-                        tc.remove(get_runmode)
-                    for i in range(0, retry_value):
-                        copy_tc = copy.deepcopy(tc)
-                        copy_tc.find("retry").set("attempt", i+1)
-                        testcase_list.append(copy_tc)
-            if retry_type is None and runmode is None:
-                testcase_list.append(tc)
-        return testcase_list
-
-
 def report_testsuite_result(suite_repository, suite_status):
     """Reports the result of the testsuite executed
     Arguments:
@@ -297,7 +197,8 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
     initialize_suite_fields(data_repository)
     suite_repository = get_suite_details(testsuite_filepath, data_repository,
                                          from_project, res_startdir, logs_startdir)
-    testcase_list = get_testcase_list(testsuite_filepath)
+    testcase_list = common_execution_utils.get_step_list(testsuite_filepath,
+                                                         "Testcases", "Testcase")
     execution_type = suite_repository['suite_exectype'].upper()
     no_of_tests = str(len(testcase_list))
 

--- a/warrior/WarriorCore/testsuite_driver.py
+++ b/warrior/WarriorCore/testsuite_driver.py
@@ -278,6 +278,10 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
     if not from_project:
         data_repository["war_parallel"] = False
 
+    root = Utils.xml_Utils.getRoot(testsuite_filepath)
+    suite_global_xml = root.find('Details')
+    runmode, value, _ = common_execution_utils.get_runmode_from_xmlfile(suite_global_xml)
+
     if execution_type.upper() == 'PARALLEL_TESTCASES':
         ts_junit_object.remove_html_obj()
         data_repository["war_parallel"] = True
@@ -288,12 +292,54 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
                                                           auto_defects=auto_defects)
 
     elif execution_type.upper() == 'SEQUENTIAL_TESTCASES':
-        print_info("Executing testccases sequentially")
-        test_suite_status = sequential_testcase_driver.main(testcase_list, suite_repository,
-                                                            data_repository, from_project,
-                                                            auto_defects=auto_defects)
+        if runmode is None:
+            print_info("Executing testcases sequentially")
+            test_suite_status = sequential_testcase_driver.main(testcase_list, suite_repository,
+                                                                data_repository, from_project,
+                                                                auto_defects=auto_defects)
 
-    elif execution_type.upper() == 'RUN_UNTIL_FAIL':
+        elif runmode.upper() is "RUF":
+            print_info("Execution type: {0}, Attempts: {1}".format(runmode, value))
+            i = 0
+            while i < int(value):
+                i += 1
+                print_debug("\n\n<======= ATTEMPT: {0} ======>".format(i))
+                test_suite_status = sequential_testcase_driver.main(testcase_list, suite_repository,
+                                                                    data_repository, from_project,
+                                                                    auto_defects=auto_defects)
+                test_count = i * len(testcase_list)
+                testsuite_utils.pSuite_update_suite_tests(str(test_count))
+                if str(test_suite_status).upper() == "FALSE" or\
+                   str(test_suite_status).upper() == "ERROR":
+                    break
+
+        elif runmode.upper() is "RUP":
+            print_info("Execution type: {0}, Attempts: {1}".format(runmode, value))
+            i = 0
+            while i < int(value):
+                i += 1
+                print_debug("\n\n<======= ATTEMPT: {0} ======>".format(i))
+                test_suite_status = sequential_testcase_driver.main(testcase_list, suite_repository,
+                                                                    data_repository, from_project,
+                                                                    auto_defects=auto_defects)
+                test_count = i * len(testcase_list)
+                testsuite_utils.pSuite_update_suite_tests(str(test_count))
+                if str(test_suite_status).upper() == "TRUE":
+                    break
+
+        elif runmode.upper() is "RMT":
+            print_info("Execution type: {0}, Attempts: {1}".format(runmode, value))
+            i = 0
+            while i < int(value):
+                i += 1
+                print_debug("\n\n<======= ATTEMPT: {0} ======>".format(i))
+                # We aren't actually summing each test result here...
+                test_suite_status = sequential_testcase_driver.main(testcase_list, suite_repository,
+                                                                    data_repository, from_project,
+                                                                    auto_defects=auto_defects)
+
+    # The below code is not modified/removed to preserve backward compatibility
+    elif execution_type.upper() == 'RUN_UNTIL_FAIL' and runmode is None:
         execution_value = Utils.xml_Utils.getChildAttributebyParentTag(testsuite_filepath,
                                                                        'Details',
                                                                        'type', 'Max_Attempts')
@@ -312,7 +358,7 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
                str(test_suite_status).upper() == "ERROR":
                 break
 
-    elif execution_type.upper() == 'RUN_UNTIL_PASS':
+    elif execution_type.upper() == 'RUN_UNTIL_PASS' and runmode is None:
         execution_value = Utils.xml_Utils.getChildAttributebyParentTag(testsuite_filepath,
                                                                        'Details',
                                                                        'type', 'Max_Attempts')
@@ -330,7 +376,7 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
             if str(test_suite_status).upper() == "TRUE":
                 break
 
-    elif execution_type.upper() == 'RUN_MULTIPLE':
+    elif execution_type.upper() == 'RUN_MULTIPLE' and runmode is None:
         execution_value = Utils.xml_Utils.getChildAttributebyParentTag(testsuite_filepath,
                                                                         'Details', 'type',
                                                                         'Number_Attempts')

--- a/warrior/WarriorCore/testsuite_driver.py
+++ b/warrior/WarriorCore/testsuite_driver.py
@@ -297,6 +297,7 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
         execution_value = Utils.xml_Utils.getChildAttributebyParentTag(testsuite_filepath,
                                                                        'Details',
                                                                        'type', 'Max_Attempts')
+        execution_value = 1 if execution_value == "" else execution_value
         print_info("Execution type: {0}, Attempts: {1}".format(execution_type, execution_value))
         i = 0
         while i < int(execution_value):
@@ -315,6 +316,7 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
         execution_value = Utils.xml_Utils.getChildAttributebyParentTag(testsuite_filepath,
                                                                        'Details',
                                                                        'type', 'Max_Attempts')
+        execution_value = 1 if execution_value == "" else execution_value
         print_info("Execution type: {0}, Attempts: {1}".format(execution_type, execution_value))
         i = 0
         while i < int(execution_value):
@@ -332,7 +334,8 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
         execution_value = Utils.xml_Utils.getChildAttributebyParentTag(testsuite_filepath,
                                                                         'Details', 'type',
                                                                         'Number_Attempts')
-        print_info("Execution type: {0}, Max Attempts: {1}".format(execution_type, execution_value))
+        execution_value = 1 if execution_value == "" else execution_value
+        print_info("Execution type: {0}, Attempts: {1}".format(execution_type, execution_value))
 
         i = 0
         while i < int(execution_value):

--- a/warrior/WarriorCore/testsuite_driver.py
+++ b/warrior/WarriorCore/testsuite_driver.py
@@ -298,7 +298,7 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
                                                                 data_repository, from_project,
                                                                 auto_defects=auto_defects)
 
-        elif runmode.upper() is "RUF":
+        elif runmode.upper() == "RUF":
             print_info("Execution type: {0}, Attempts: {1}".format(runmode, value))
             i = 0
             while i < int(value):
@@ -313,7 +313,7 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
                    str(test_suite_status).upper() == "ERROR":
                     break
 
-        elif runmode.upper() is "RUP":
+        elif runmode.upper() == "RUP":
             print_info("Execution type: {0}, Attempts: {1}".format(runmode, value))
             i = 0
             while i < int(value):
@@ -327,7 +327,7 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
                 if str(test_suite_status).upper() == "TRUE":
                     break
 
-        elif runmode.upper() is "RMT":
+        elif runmode.upper() == "RMT":
             print_info("Execution type: {0}, Attempts: {1}".format(runmode, value))
             i = 0
             while i < int(value):
@@ -338,7 +338,7 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
                                                                     data_repository, from_project,
                                                                     auto_defects=auto_defects)
 
-    # The below code is not modified/removed to preserve backward compatibility
+    # The below runmode part is not modified/removed to preserve backward compatibility
     elif execution_type.upper() == 'RUN_UNTIL_FAIL' and runmode is None:
         execution_value = Utils.xml_Utils.getChildAttributebyParentTag(testsuite_filepath,
                                                                        'Details',

--- a/wftests/warrior_tests/projects/pj_runmode_tests.xml
+++ b/wftests/warrior_tests/projects/pj_runmode_tests.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" ?>
+<Project>
+    <Details>
+        <Name>pj_runmode_at_tc_&_suite_level_at_project_file</Name>
+        <Title>Project for testing runmode tag in suite files & testcase levels</Title>
+        <Engineer>Warrior_user</Engineer>
+        <State>New</State>
+        <Date>07-18-2018</Date>
+        <Time>11:59:51</Time>
+        <default_onError action="next"/>
+    </Details>
+    <Testsuites>
+
+ <!-- runmode at suite local level -->
+        <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_rmt_at_ts_local_level.xml</path>
+            <onError action="next" value=""/>
+            <impact>noimpact</impact>
+        </Testsuite>
+        <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_rup_at_ts_local_level.xml</path>
+            <onError action="next" value=""/>
+            <impact>noimpact</impact>
+        </Testsuite>
+        <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_ruf_at_ts_local_level.xml</path>
+            <onError action="next" value=""/>
+            <impact>noimpact</impact>
+        </Testsuite>
+
+        <!-- verify runmode at suite global level -->
+        <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_verify_at_ts_local_level.xml</path>
+            <onError action="next" value=""/>
+            <impact>impact</impact>
+        </Testsuite>
+
+<!-- runmode at suite global level -->
+        <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_rmt_at_ts_global_level_with_new_tag.xml</path>
+            <onError action="next" value=""/>
+            <impact>impact</impact>
+        </Testsuite>
+        <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_rup_at_ts_global_level_with_new_tag.xml</path>
+            <onError action="next" value=""/>
+            <impact>impact</impact>
+        </Testsuite>
+        <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_ruf_at_ts_global_level_with_new_tag.xml</path>
+            <onError action="next" value=""/>
+            <impact>noimpact</impact>
+        </Testsuite>
+
+        <!-- verify runmode at suite global level -->
+        <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_verify_at_ts_global_level.xml</path>
+            <onError action="next" value=""/>
+            <impact>impact</impact>
+        </Testsuite>
+
+ <!-- runmode at project local level  -->
+        <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_rmt_at_pj_local_level.xml</path>
+            <onError action="next" value=""/>
+	    <runmode type="RMT" value="3"/>
+            <impact>noimpact</impact>
+        </Testsuite>
+        <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_rup_at_pj_local_level.xml</path>
+            <onError action="next" value=""/>
+	    <runmode type="RUP" value="7"/>
+            <impact>noimpact</impact>
+        </Testsuite>
+        <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_ruf_at_pj_local_level.xml</path>
+            <onError action="next" value=""/>
+	    <runmode type="RUF" value="7"/>
+            <impact>noimpact</impact>
+        </Testsuite>
+
+        <!-- verify runmode at project global level -->
+        <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_verify_at_pj_local_level.xml</path>
+            <onError action="next" value=""/>
+            <impact>impact</impact> 
+        </Testsuite>
+
+<!-- runmode at case local level -->
+        <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_at_tc_local_level.xml</path>
+            <onError action="next" value=""/>
+            <impact>impact</impact>
+        </Testsuite>
+
+   </Testsuites>
+</Project>
+
+

--- a/wftests/warrior_tests/projects/pj_runmode_tests.xml
+++ b/wftests/warrior_tests/projects/pj_runmode_tests.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <Project>
     <Details>
-        <Name>pj_runmode_at_tc_&_suite_level_at_project_file</Name>
-        <Title>Project for testing runmode tag in suite files & testcase levels</Title>
+        <Name>pj_runmode_at_tc_and_suite_level_at_project_file</Name>
+        <Title>Project for testing runmode tag in suite and testcase files</Title>
         <Engineer>Warrior_user</Engineer>
         <State>New</State>
         <Date>07-18-2018</Date>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_at_tc_local_level.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_at_tc_local_level.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_at_tc_local_level</Name>
+                <Title>test suite to run runmode at step level </Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:37:26</Time>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_tc_local_level.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+		 <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_rup_at_tc_local_level.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+		 <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_tc_local_level.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rmt_at_pj_local_level.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rmt_at_pj_local_level.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_rmt_at_pj_local_level</Name>
+                <Title>test suite to run runmode(RMT) at project file local section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:37:26</Time>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_pj_local_level.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rmt_at_ts_global_level_with_new_tag.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rmt_at_ts_global_level_with_new_tag.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_rmt_at_ts_global_level</Name>
+                <Title>test suite to run runmode(RMT) at testsuite file detail section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>2017-10-31</Date>
+                <Time>11:37:26</Time>
+                <runmode type="RMT" value="3"/>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_ts_global_level.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rmt_at_ts_local_level.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rmt_at_ts_local_level.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_rmt_at_ts_local_level</Name>
+                <Title>test suite to run runmode(RMT) at testsuite file local section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:37:26</Time>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_ts_local_level.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+			<runmode type="RMT" value="3"/>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_ruf_at_pj_local_level.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_ruf_at_pj_local_level.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_ruf_at_pj_local_level</Name>
+                <Title>test suite to run runmode(RUF) at project file local section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:37:26</Time>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_pj_local_level.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_ruf_at_ts_global_level_with_new_tag.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_ruf_at_ts_global_level_with_new_tag.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_ruf_at_ts_global_level</Name>
+                <Title>test suite to run runmode(RUF) at testsuite file detail section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:37:26</Time>
+                <runmode type="RUF" value="50"/>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_ts_global_level.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_ruf_at_ts_local_level.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_ruf_at_ts_local_level.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_ruf_at_ts_local_level</Name>
+                <Title>test suite to run runmode(RMT) at testsuite file local section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:37:26</Time>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_ts_local_level.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+			<runmode type="RUF" value="7"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rup_at_pj_local_level.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rup_at_pj_local_level.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_rup_at_pj_local_level</Name>
+                <Title>test suite to run runmode(RUP) at project file section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:37:26</Time>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_rup_at_pj_local_level.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rup_at_ts_global_level_with_new_tag.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rup_at_ts_global_level_with_new_tag.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_rup_at_ts_global_level</Name>
+                <Title>test suite to run runmode(RMT) at testsuite file detail section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:37:26</Time>
+                <runmode type="RUP" value="40"/>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_rup_at_ts_global_level.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rup_at_ts_local_level.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rup_at_ts_local_level.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_rup_at_ts_local_level</Name>
+                <Title>test suite to run runmode(RMT) at testsuite file local section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:37:26</Time>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_rup_at_ts_local_level.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+			<runmode type="RUP" value="7"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_verify_at_pj_local_level.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_verify_at_pj_local_level.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_verify_at_pj_local_level</Name>
+                <Title>test suite to verify runmode at project file local section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:41:26</Time>
+                <type exectype="sequential_testcases"/>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_verify_at_pj_local_level.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>
+

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_verify_at_ts_local_level.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_verify_at_ts_local_level.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_verify_at_ts_local_level</Name>
+                <Title>test suite to verify runmode at testsuite file local section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:41:26</Time>
+                <type exectype="sequential_testcases"/>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_verify_at_ts_local_level.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_pj_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_pj_local_level.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_rmt_at_pj_local_level</Name>
+                <Title>Test the runmode functionality specified at project file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="pj_rmt_count_local"/>
+                                <argument name="status" value="fail"/>
+                                <argument name="max_value" value="3"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_tc_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_tc_local_level.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_rmt_at_tc_local_level</Name>
+                <Title>Test the runmode functionality specified at testcase local level</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="tc_rmt"/>
+                                <argument name="status" value="pass"/>
+                                <argument name="max_value" value="4"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+			<runmode type="RMT" value="4"/>
+                        <impact>impact</impact>
+                </step>
+		<step Driver="common_driver" Keyword="verify_data" TS="2" draft="no">
+                        <Arguments>
+                                <argument name="expected" value="4"/>
+                                <argument name="comparison" value="eq"/>
+                                <argument name="type" value="int"/>
+                                <argument name="object_key" value="tc_rmt"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description/>
+                        <iteration_type type=""/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_ts_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_ts_local_level.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_rmt_at_ts_local_level</Name>
+                <Title>Test the runmode functionality specified at testsuite file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="ts_rmt_count_local"/>
+                                <argument name="status" value="fail"/>
+                                <argument name="max_value" value="3"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_pj_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_pj_local_level.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_ruf_at_pj_local_level</Name>
+                <Title>Test the runmode functionality specified at project file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="pj_ruf_count_local"/>
+                                <argument name="status" value="pass"/>
+                                <argument name="max_value" value="5"/>
+                                <argument name="max_status" value="fail"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_tc_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_tc_local_level.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_ruf_at_tc_local_level</Name>
+                <Title>Test the runmode functionality specified at testcase local level</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="tc_ruf"/>
+                                <argument name="status" value="pass"/>
+                                <argument name="max_value" value="4"/>
+                                <argument name="max_status" value="fail"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+			<runmode type="RUF" value="10"/>
+                        <impact>noimpact</impact>
+                </step>
+		 <step Driver="common_driver" Keyword="verify_data" TS="2" draft="no">
+                        <Arguments>
+                                <argument name="expected" value="4"/>
+                                <argument name="comparison" value="eq"/>
+                                <argument name="type" value="int"/>
+                                <argument name="object_key" value="tc_ruf"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description/>
+                        <iteration_type type=""/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+               </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_ts_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_ts_local_level.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_ruf_at_ts_local_level</Name>
+                <Title>Test the runmode functionality specified at testsuite file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="ts_ruf_count_local"/>
+                                <argument name="status" value="pass"/>
+                                <argument name="max_value" value="5"/>
+                                <argument name="max_status" value="fail"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_pj_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_pj_local_level.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_rup_at_pj_local_level</Name>
+                <Title>Test the runmode functionality specified at project file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="pj_rup_count_local"/>
+                                <argument name="status" value="fail"/>
+                                <argument name="max_value" value="4"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_tc_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_tc_local_level.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_rup_at_tc_local_level</Name>
+                <Title>Test the runmode functionality specified at testcase local level</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="tc_rup"/>
+                                <argument name="status" value="fail"/>
+                                <argument name="max_value" value="4"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+			<runmode type="RUP" value="10"/>
+                        <impact>noimpact</impact>
+	      </step>
+	      <step Driver="common_driver" Keyword="verify_data" TS="2" draft="no">
+                        <Arguments>
+                                <argument name="expected" value="4"/>
+                                <argument name="comparison" value="eq"/>
+                                <argument name="type" value="int"/>
+                                <argument name="object_key" value="tc_rup"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description/>
+                        <iteration_type type=""/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_ts_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_ts_local_level.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_rup_at_ts_local_level</Name>
+                <Title>Test the runmode functionality specified at testsuite file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="ts_rup_count_local"/>
+                                <argument name="status" value="fail"/>
+                                <argument name="max_value" value="4"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_verify_at_pj_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_verify_at_pj_local_level.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_verify_at_pj_local_level</Name>
+                <Title>Verify the runmode functionality specified at project file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="3"/>
+                                <argument name="object_key" value="pj_rmt_count_local"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+                <step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="4"/>
+                                <argument name="object_key" value="pj_rup_count_local"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+                <step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="5"/>
+                                <argument name="object_key" value="pj_ruf_count_local"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_verify_at_ts_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_verify_at_ts_local_level.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_verify_at_ts_local_level</Name>
+                <Title>Verify the runmode functionality specified at testsuite file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="3"/>
+                                <argument name="object_key" value="ts_rmt_count_local"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+                <step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="4"/>
+                                <argument name="object_key" value="ts_rup_count_local"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+                <step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="5"/>
+                                <argument name="object_key" value="ts_ruf_count_local"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>


### PR DESCRIPTION
Requirement:
1. To modularize runmode across all the levels in Warrior.

Existing:
1. All local levels in Warrior has the same format for runmode.
   runmode type="RMT/RUP/RUF" value=""
2. Suite global levels uses a different format.
   type exectype="Run_Until_Pass/Run_Until_Fail" Max_Attempts=""
   type exectype="Run_Multiple" Number_Attempts=""

Fix Explanation:
1. The below format can be used in all levels of Warrior without affecting backward compatibility.
   runmode type="RMT/RUP/RUF" value=""
2.  To set the default value as 1 for runmode if the value is not provided.
3.  As a cleanup, the method to get the list of steps/testcases/suites in testcase/testsuite/project drivers 
     is moved as a common method "get_step_list" in common_execution_utils.

Adding the regression logs and instruction for testing in Jira.
