### PR TITLE
WAR-542: As a user, I want to know if a step/testcase passed all attempts when that it was set to RUF & RUP

### DIFF
--- a/warrior/WarriorCore/common_execution_utils.py
+++ b/warrior/WarriorCore/common_execution_utils.py
@@ -40,6 +40,7 @@ def append_step_list(step_list, step, value, go_next, mode, tag):
         copy_step = copy.deepcopy(step)
         copy_step.find(mode).set(tag, go_next)
         copy_step.find(mode).set("attempt", i + 1)
+        copy_step.find(mode).set(mode+"_val", value)
         step_list.append(copy_step)
     return step_list
 

--- a/warrior/WarriorCore/project_driver.py
+++ b/warrior/WarriorCore/project_driver.py
@@ -160,6 +160,7 @@ def get_testsuite_list(project_filepath):
                     copy_ts = copy.deepcopy(ts)
                     copy_ts.find("runmode").set("value", go_next)
                     copy_ts.find("runmode").set("attempt", i+1)
+                    copy_ts.find("runmode").set("runmode_value", value)
                     testsuite_list.append(copy_ts)
             if retry_type is not None and retry_value > 0:
                 if len(new_testsuite_list) > 1:

--- a/warrior/WarriorCore/project_driver.py
+++ b/warrior/WarriorCore/project_driver.py
@@ -260,7 +260,6 @@ def execute_project(project_filepath, auto_defects, jiraproj, res_startdir, logs
         print_error("unexpected project_type received...aborting execution")
         project_status = False
 
-    print_info("\n")
     project_end_time = Utils.datetime_utils.get_current_timestamp()
     print_info("[{0}] Project execution completed".format(project_end_time))
     project_duration = Utils.datetime_utils.get_time_delta(project_start_time)

--- a/warrior/WarriorCore/sequential_testcase_driver.py
+++ b/warrior/WarriorCore/sequential_testcase_driver.py
@@ -114,12 +114,12 @@ def execute_sequential_testcases(testcase_list, suite_repository,
             if testcase.find("runmode").get("attempt") == 1:
                 print_info("\n----------------- Start of Testcase Runmode Execution"
                            " -----------------\n")
-            print_info("TESTCASE ATTEMPT: {0}".format(
-                                testcase.find("runmode").get("attempt")))
+            print_info("TESTCASE ATTEMPT: {0}".format(testcase.find("runmode")
+                                                      .get("attempt")))
         if testcase.find("retry") is not None and \
            testcase.find("retry").get("attempt") is not None:
-            print_info("TESTCASE ATTEMPT: {0}".format(
-                                testcase.find("retry").get("attempt")))
+            print_info("TESTCASE ATTEMPT: {0}".format(testcase.find("retry")
+                                                      .get("attempt")))
 
         if Utils.file_Utils.fileExists(tc_path) or action is False:
             tc_name = Utils.file_Utils.getFileName(tc_path)
@@ -384,7 +384,7 @@ def execute_sequential_testcases(testcase_list, suite_repository,
     if testcase.find("runmode") is not None and \
        testcase.find("runmode").get("attempt") is not None:
         if testcase.find("runmode").get("attempt") == \
-           testcase.find("runmode").get("runmode_value"):
+           testcase.find("runmode").get("runmode_val"):
             print_info("\n----------------- End of Testcase Runmode Execution"
                        " -----------------\n")
     suite_status = Utils.testcase_Utils.compute_status_using_impact(

--- a/warrior/WarriorCore/sequential_testcase_driver.py
+++ b/warrior/WarriorCore/sequential_testcase_driver.py
@@ -80,7 +80,6 @@ def execute_sequential_testcases(testcase_list, suite_repository,
     impact_dict = {"IMPACT": "Impact", "NOIMPACT": "No Impact"}
     tc_duration_list = []
     tc_junit_list = []
-    runmode_count = 0
 
     while tests < len(testcase_list):
         testcase = testcase_list[tests]
@@ -111,9 +110,8 @@ def execute_sequential_testcases(testcase_list, suite_repository,
         data_repository['wt_tc_impact'] = tc_impact
         if testcase.find("runmode") is not None and \
            testcase.find("runmode").get("attempt") is not None:
-            runmode_count += 1
             # condition to print the start of runmode execution
-            if runmode_count == 1:
+            if testcase.find("runmode").get("attempt") == 1:
                 print_info("\n----------------- Start of Testcase Runmode Execution"
                            " -----------------\n")
             print_info("TESTCASE ATTEMPT: {0}".format(
@@ -177,14 +175,6 @@ def execute_sequential_testcases(testcase_list, suite_repository,
                 testsuite_utils.pSuite_update_suite_attributes(
                                 junit_resultfile, str(errors), str(skipped),
                                 str(tests), str(failures), time='0')
-                # print the end of runmode execution as the steps skip when the condition
-                # is met for RUF/RUP
-                if testcase.find("runmode") is not None and \
-                   testcase.find("runmode").get("attempt") is not None:
-                    if testcase.find("runmode").get("attempt") == \
-                       testcase.find("runmode").get("value")-1:
-                            print_info("\n----------------- End of Testcase Runmode Execution"
-                                       " -----------------\n")
                 data_repository['wt_junit_object'].update_count(
                                 "skipped", "1", "ts",
                                 data_repository['wt_ts_timestamp'])
@@ -276,10 +266,6 @@ def execute_sequential_testcases(testcase_list, suite_repository,
         retry_type, retry_cond, retry_cond_value, retry_value, \
             retry_interval = common_execution_utils.get_retry_from_xmlfile(testcase)
         if runmode is not None:
-            # print the end of runmode execution when all the attempts finish
-            if runmode_count == value-1:
-                print_info("\n----------------- End of Testcase Runmode Execution"
-                           " -----------------\n")
             if tc_status is True:
                 testsuite_utils.update_tc_duration(str(tc_duration))
                 # if runmode is 'rup' & tc_status is True, skip the repeated
@@ -392,7 +378,14 @@ def execute_sequential_testcases(testcase_list, suite_repository,
     # same system for 'iterative_parallel' suite execution
     if ts_iter is True:
         tc_junit_list = data_repository['wt_junit_object']
-
+    # print the end of runmode execution as the steps skip when the condition
+    # is met for RUF/RUP or when all the attempts finish
+    if testcase.find("runmode") is not None and \
+       testcase.find("runmode").get("attempt") is not None:
+        if testcase.find("runmode").get("attempt") == \
+           testcase.find("runmode").get("runmode_value"):
+            print_info("\n----------------- End of Testcase Runmode Execution"
+                       " -----------------\n")
     suite_status = Utils.testcase_Utils.compute_status_using_impact(
                                         tc_status_list, tc_impact_list)
 

--- a/warrior/WarriorCore/sequential_testcase_driver.py
+++ b/warrior/WarriorCore/sequential_testcase_driver.py
@@ -179,10 +179,12 @@ def execute_sequential_testcases(testcase_list, suite_repository,
                                 str(tests), str(failures), time='0')
                 # print the end of runmode execution as the steps skip when the condition
                 # is met for RUF/RUP
-                if testcase.find("runmode").get("attempt") == \
-                   testcase.find("runmode").get("value")-1:
-                    print_info("\n----------------- End of Testcase Runmode Execution"
-                               " -----------------\n")
+                if testcase.find("runmode") is not None and \
+                   testcase.find("runmode").get("attempt") is not None:
+                    if testcase.find("runmode").get("attempt") == \
+                       testcase.find("runmode").get("value")-1:
+                            print_info("\n----------------- End of Testcase Runmode Execution"
+                                       " -----------------\n")
                 data_repository['wt_junit_object'].update_count(
                                 "skipped", "1", "ts",
                                 data_repository['wt_ts_timestamp'])

--- a/warrior/WarriorCore/sequential_testcase_driver.py
+++ b/warrior/WarriorCore/sequential_testcase_driver.py
@@ -80,6 +80,7 @@ def execute_sequential_testcases(testcase_list, suite_repository,
     impact_dict = {"IMPACT": "Impact", "NOIMPACT": "No Impact"}
     tc_duration_list = []
     tc_junit_list = []
+    runmode_count = 0
 
     while tests < len(testcase_list):
         testcase = testcase_list[tests]
@@ -110,11 +111,14 @@ def execute_sequential_testcases(testcase_list, suite_repository,
         data_repository['wt_tc_impact'] = tc_impact
         if testcase.find("runmode") is not None and \
            testcase.find("runmode").get("attempt") is not None:
-            print_info("testcase attempt: {0}".format(
+            runmode_count += 1
+            if runmode_count == 1:
+                print_info("----------------------Start of Runmode Execution-----------------------")
+            print_info("TESTCASE ATTEMPT: {0}".format(
                                 testcase.find("runmode").get("attempt")))
         if testcase.find("retry") is not None and \
            testcase.find("retry").get("attempt") is not None:
-            print_info("testcase attempt: {0}".format(
+            print_info("TESTCASE ATTEMPT: {0}".format(
                                 testcase.find("retry").get("attempt")))
 
         if Utils.file_Utils.fileExists(tc_path):
@@ -262,6 +266,8 @@ def execute_sequential_testcases(testcase_list, suite_repository,
         retry_type, retry_cond, retry_cond_value, retry_value, \
             retry_interval = common_execution_utils.get_retry_from_xmlfile(testcase)
         if runmode is not None:
+            if runmode_count == value-1:
+                print_info("--------------------End of Runmode Execution--------------------")
             if tc_status is True:
                 testsuite_utils.update_tc_duration(str(tc_duration))
                 # if runmode is 'rup' & tc_status is True, skip the repeated

--- a/warrior/WarriorCore/sequential_testcase_driver.py
+++ b/warrior/WarriorCore/sequential_testcase_driver.py
@@ -112,8 +112,10 @@ def execute_sequential_testcases(testcase_list, suite_repository,
         if testcase.find("runmode") is not None and \
            testcase.find("runmode").get("attempt") is not None:
             runmode_count += 1
+            # condition to print the start of runmode execution
             if runmode_count == 1:
-                print_info("----------------------Start of Runmode Execution-----------------------")
+                print_info("\n----------------- Start of Testcase Runmode Execution"
+                           " -----------------\n")
             print_info("TESTCASE ATTEMPT: {0}".format(
                                 testcase.find("runmode").get("attempt")))
         if testcase.find("retry") is not None and \
@@ -175,6 +177,12 @@ def execute_sequential_testcases(testcase_list, suite_repository,
                 testsuite_utils.pSuite_update_suite_attributes(
                                 junit_resultfile, str(errors), str(skipped),
                                 str(tests), str(failures), time='0')
+                # print the end of runmode execution as the steps skip when the condition
+                # is met for RUF/RUP
+                if testcase.find("runmode").get("attempt") == \
+                   testcase.find("runmode").get("value")-1:
+                    print_info("\n----------------- End of Testcase Runmode Execution"
+                               " -----------------\n")
                 data_repository['wt_junit_object'].update_count(
                                 "skipped", "1", "ts",
                                 data_repository['wt_ts_timestamp'])
@@ -266,13 +274,15 @@ def execute_sequential_testcases(testcase_list, suite_repository,
         retry_type, retry_cond, retry_cond_value, retry_value, \
             retry_interval = common_execution_utils.get_retry_from_xmlfile(testcase)
         if runmode is not None:
+            # print the end of runmode execution when all the attempts finish
             if runmode_count == value-1:
-                print_info("--------------------End of Runmode Execution--------------------")
+                print_info("\n----------------- End of Testcase Runmode Execution"
+                           " -----------------\n")
             if tc_status is True:
                 testsuite_utils.update_tc_duration(str(tc_duration))
                 # if runmode is 'rup' & tc_status is True, skip the repeated
                 # execution of same testcase and move to next actual testcase
-                if runmode == "rup":
+                if runmode.upper() == "RUP":
                     goto_tc = str(value)
             elif tc_status == 'ERROR' or tc_status == 'EXCEPTION':
                 errors += 1
@@ -310,7 +320,7 @@ def execute_sequential_testcases(testcase_list, suite_repository,
                     goto_tc = False
                 # if runmode is 'ruf' & tc_status is False, skip the repeated
                 # execution of same testcase and move to next actual testcase
-                if not goto_tc and runmode == "ruf":
+                if not goto_tc and runmode.upper() == "RUF":
                     goto_tc = str(value)
         elif retry_type is not None:
             if retry_type.upper() == 'IF':

--- a/warrior/WarriorCore/sequential_testsuite_driver.py
+++ b/warrior/WarriorCore/sequential_testsuite_driver.py
@@ -12,9 +12,6 @@ limitations under the License.
 '''
 
 # !/usr/bin/python
-"""This is sequential suite driver which is used to execute
-the suites of a project in sequential order"""
-
 import os
 import time
 import traceback
@@ -26,6 +23,9 @@ from WarriorCore import exec_type_driver
 import WarriorCore.testsuite_driver as testsuite_driver
 import WarriorCore.onerror_driver as onerror_driver
 from Framework.Utils.testcase_Utils import pNote
+
+"""This is sequential suite driver which is used to execute
+the suites of a project in sequential order"""
 
 
 def execute_sequential_testsuites(testsuite_list, project_repository,
@@ -142,7 +142,8 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
         pj_junit_object.update_attr("impact", impact_dict.
                                     get(testsuite_impact.upper()), "ts",
                                     data_repository['wt_ts_timestamp'])
-        pj_junit_object.update_attr("onerror", onerror, "ts", data_repository['wt_ts_timestamp'])
+        pj_junit_object.update_attr("onerror", onerror, "ts",
+                                    data_repository['wt_ts_timestamp'])
 
         string_status = {"TRUE": "PASS", "FALSE": "FAIL", "ERROR": "ERROR",
                          "SKIP": "SKIP", "RAN": "RAN"}

--- a/warrior/WarriorCore/sequential_testsuite_driver.py
+++ b/warrior/WarriorCore/sequential_testsuite_driver.py
@@ -33,6 +33,7 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
     """ Executes suites in a project sequentially """
 
     suite_cntr = 0
+    runmode_count = 0
     goto_testsuite = False
     ts_status_list = []
     ts_impact_list = []
@@ -67,6 +68,13 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
                                                                                     'onError',
                                                                                     'action')
         ts_onError_action = ts_onError_action if ts_onError_action else project_error_action
+        if testsuite.find("runmode") is not None and \
+           testsuite.find("runmode").get("attempt") is not None:
+                runmode_count += 1
+                if runmode_count == 1:
+                    print_info("----------------------Start of Runmode Execution-----------------------")
+                print_info("RUNMODE ATTEMPT: {0}"
+                           .format(testsuite.find("runmode").get("attempt")))
         if Utils.file_Utils.fileExists(testsuite_path):
             if not goto_testsuite and action is True:
 
@@ -158,9 +166,8 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
         retry_type, retry_cond, retry_cond_value, retry_value,\
             retry_interval = common_execution_utils.get_retry_from_xmlfile(testsuite)
         if runmode is not None:
-            if testsuite.find("runmode") is not None and\
-              testsuite.find("runmode").get("attempt") is not None:
-                print_info("runmode attempt: {0}".format(testsuite.find("runmode").get("attempt")))
+            if runmode_count == value-1:
+                print_info("--------------------End of Runmode Execution--------------------")
             # if runmode is 'ruf' & step_status is False, skip the repeated
             # execution of same TC step and move to next actual step
             if not project_error_value and runmode == "RUF" and\
@@ -173,7 +180,8 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
         elif retry_type is not None:
             if testsuite.find("retry") is not None and\
               testsuite.find("retry").get("attempt") is not None:
-                print_info("retry attempt: {0}".format(testsuite.find("retry").get("attempt")))
+                print_info("RETRY ATTEMPT: {0}"
+                           .format(testsuite.find("retry").get("attempt")))
             if retry_type.upper() == 'IF':
                 try:
                     if data_repository[retry_cond] == retry_cond_value:

--- a/warrior/WarriorCore/sequential_testsuite_driver.py
+++ b/warrior/WarriorCore/sequential_testsuite_driver.py
@@ -71,8 +71,10 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
         if testsuite.find("runmode") is not None and \
            testsuite.find("runmode").get("attempt") is not None:
                 runmode_count += 1
+                # condition to print the start of runmode execution
                 if runmode_count == 1:
-                    print_info("----------------------Start of Runmode Execution-----------------------")
+                    print_info("\n----------------- Start of Testsuite Runmode Execution"
+                               " -----------------\n")
                 print_info("RUNMODE ATTEMPT: {0}"
                            .format(testsuite.find("runmode").get("attempt")))
         if Utils.file_Utils.fileExists(testsuite_path):
@@ -103,6 +105,12 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
 
             else:
                 msg = print_info('skipped testsuite: {0} '.format(testsuite_path))
+                # print the end of runmode execution as the steps skip when the condition
+                # is met for RUF/RUP
+                if testsuite.find("runmode").get("attempt") == \
+                   testsuite.find("runmode").get("value")-1:
+                    print_info("\n----------------- End of Testsuite Runmode Execution"
+                               " -----------------\n")
                 tmp_timestamp = str(Utils.datetime_utils.get_current_timestamp())
                 time.sleep(2)
                 pj_junit_object.create_testsuite(
@@ -167,8 +175,10 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
         retry_type, retry_cond, retry_cond_value, retry_value,\
             retry_interval = common_execution_utils.get_retry_from_xmlfile(testsuite)
         if runmode is not None:
+            # print the end of runmode execution when all the attempts finish
             if runmode_count == value-1:
-                print_info("--------------------End of Runmode Execution--------------------")
+                print_info("\n----------------- End of Testsuite Runmode Execution"
+                           " -----------------\n")
             # if runmode is 'ruf' & step_status is False, skip the repeated
             # execution of same TC step and move to next actual step
             if not project_error_value and runmode == "RUF" and\

--- a/warrior/WarriorCore/sequential_testsuite_driver.py
+++ b/warrior/WarriorCore/sequential_testsuite_driver.py
@@ -240,7 +240,7 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
     if testsuite.find("runmode") is not None and \
        testsuite.find("runmode").get("attempt") is not None:
         if testsuite.find("runmode").get("attempt") == \
-           testsuite.find("runmode").get("runmode_value"):
+           testsuite.find("runmode").get("runmode_val"):
             print_info("\n----------------- End of Testsuite Runmode Execution"
                        " -----------------\n")
     project_status = Utils.testcase_Utils.compute_status_using_impact(ts_status_list,

--- a/warrior/WarriorCore/sequential_testsuite_driver.py
+++ b/warrior/WarriorCore/sequential_testsuite_driver.py
@@ -33,7 +33,6 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
     """ Executes suites in a project sequentially """
 
     suite_cntr = 0
-    runmode_count = 0
     goto_testsuite = False
     ts_status_list = []
     ts_impact_list = []
@@ -70,9 +69,8 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
         ts_onError_action = ts_onError_action if ts_onError_action else project_error_action
         if testsuite.find("runmode") is not None and \
            testsuite.find("runmode").get("attempt") is not None:
-                runmode_count += 1
                 # condition to print the start of runmode execution
-                if runmode_count == 1:
+                if testsuite.find("runmode").get("attempt") == 1:
                     print_info("\n----------------- Start of Testsuite Runmode Execution"
                                " -----------------\n")
                 print_info("RUNMODE ATTEMPT: {0}"
@@ -105,14 +103,6 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
 
             else:
                 msg = print_info('skipped testsuite: {0} '.format(testsuite_path))
-                # print the end of runmode execution as the steps skip when the condition
-                # is met for RUF/RUP
-                if testsuite.find("runmode") is not None and \
-                   testsuite.find("runmode").get("attempt") is not None:
-                    if testsuite.find("runmode").get("attempt") == \
-                       testsuite.find("runmode").get("value")-1:
-                        print_info("\n----------------- End of Testsuite Runmode Execution"
-                                   " -----------------\n")
                 tmp_timestamp = str(Utils.datetime_utils.get_current_timestamp())
                 time.sleep(2)
                 pj_junit_object.create_testsuite(
@@ -177,10 +167,6 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
         retry_type, retry_cond, retry_cond_value, retry_value,\
             retry_interval = common_execution_utils.get_retry_from_xmlfile(testsuite)
         if runmode is not None:
-            # print the end of runmode execution when all the attempts finish
-            if runmode_count == value-1:
-                print_info("\n----------------- End of Testsuite Runmode Execution"
-                           " -----------------\n")
             # if runmode is 'ruf' & step_status is False, skip the repeated
             # execution of same TC step and move to next actual step
             if not project_error_value and runmode == "RUF" and\
@@ -249,7 +235,14 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
             elif goto_testsuite and int(goto_testsuite) < suite_cntr:
                 suite_cntr = int(goto_testsuite)-1
                 goto_testsuite = False
-
+    # print the end of runmode execution as the steps skip when the condition
+    # is met for RUF/RUP or when all the attempts finish
+    if testsuite.find("runmode") is not None and \
+       testsuite.find("runmode").get("attempt") is not None:
+        if testsuite.find("runmode").get("attempt") == \
+           testsuite.find("runmode").get("runmode_value"):
+            print_info("\n----------------- End of Testsuite Runmode Execution"
+                       " -----------------\n")
     project_status = Utils.testcase_Utils.compute_status_using_impact(ts_status_list,
                                                                       ts_impact_list)
 

--- a/warrior/WarriorCore/sequential_testsuite_driver.py
+++ b/warrior/WarriorCore/sequential_testsuite_driver.py
@@ -107,10 +107,12 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
                 msg = print_info('skipped testsuite: {0} '.format(testsuite_path))
                 # print the end of runmode execution as the steps skip when the condition
                 # is met for RUF/RUP
-                if testsuite.find("runmode").get("attempt") == \
-                   testsuite.find("runmode").get("value")-1:
-                    print_info("\n----------------- End of Testsuite Runmode Execution"
-                               " -----------------\n")
+                if testsuite.find("runmode") is not None and \
+                   testsuite.find("runmode").get("attempt") is not None:
+                    if testsuite.find("runmode").get("attempt") == \
+                       testsuite.find("runmode").get("value")-1:
+                        print_info("\n----------------- End of Testsuite Runmode Execution"
+                                   " -----------------\n")
                 tmp_timestamp = str(Utils.datetime_utils.get_current_timestamp())
                 time.sleep(2)
                 pj_junit_object.create_testsuite(

--- a/warrior/WarriorCore/step_driver.py
+++ b/warrior/WarriorCore/step_driver.py
@@ -239,7 +239,7 @@ def execute_step(step, step_num, data_repository, system_name, kw_parallel, queu
     if step.find("runmode") is not None and \
        step.find("runmode").get("attempt") is not None:
         if step.find("runmode").get("attempt") == \
-           step.find("runmode").get("runmode_value"):
+           step.find("runmode").get("runmode_val"):
             print_info("\n----------------- End of Step Runmode Execution -----------------\n")
 
     impact_dict = {"IMPACT": "Impact", "NOIMPACT": "No Impact"}

--- a/warrior/WarriorCore/step_driver.py
+++ b/warrior/WarriorCore/step_driver.py
@@ -141,16 +141,18 @@ def execute_step(step, step_num, data_repository, system_name, kw_parallel, queu
     kw_resultfile = get_keyword_resultfile(
         data_repository, system_name, step_num, keyword)
     Utils.config_Utils.set_resultfile(kw_resultfile)
+    # print the start of runmode execution
+    if step.find("runmode") is not None and \
+       step.find("runmode").get("attempt") is not None:
+        if step.find("runmode").get("attempt") == 1:
+            print_info("\n----------------- Start of Step Runmode Execution -----------------\n")
+        print_info("KEYWORD ATTEMPT: {0}".format(
+            step.find("runmode").get("attempt")))
     # print keyword to result file
     Utils.testcase_Utils.pKeyword(keyword, driver)
     print_info("step number: {0}".format(step_num))
     print_info("Teststep Description: {0}".format(step_description))
 
-    if step.find("runmode") is not None and step.find("runmode").get("attempt") is not None:
-        if step.find("runmode").get("attempt") == 1:
-            print_info("----------------------Start of Runmode Execution-----------------------")
-        print_info("KEYWORD ATTEMPT: {0}".format(
-            step.find("runmode").get("attempt")))
     if step.find("retry") is not None and step.find("retry").get("attempt") is not None:
         print_info("KEYWORD ATTEMPT: {0}".format(
             step.find("retry").get("attempt")))
@@ -237,7 +239,6 @@ def execute_step(step, step_num, data_repository, system_name, kw_parallel, queu
     impact_dict = {"IMPACT": "Impact", "NOIMPACT": "No Impact"}
     tc_timestamp = data_repository['wt_tc_timestamp']
     impact = impact_dict.get(step_impact.upper())
-
     tc_resultsdir = data_repository['wt_resultsdir']
     tc_name = data_repository['wt_name']
     add_keyword_result(tc_junit_object, tc_timestamp, step_num, keyword,

--- a/warrior/WarriorCore/step_driver.py
+++ b/warrior/WarriorCore/step_driver.py
@@ -235,6 +235,12 @@ def execute_step(step, step_num, data_repository, system_name, kw_parallel, queu
     hms = Utils.datetime_utils.get_hms_for_seconds(kw_duration)
     print_info("Keyword duration= {0}".format(hms))
     print_info("[{0}] Keyword execution completed".format(kw_end_time))
+    # condition to  print the end of runmode execution when all the attempts finish
+    if step.find("runmode") is not None and \
+       step.find("runmode").get("attempt") is not None:
+        if step.find("runmode").get("attempt") == \
+           step.find("runmode").get("runmode_value"):
+            print_info("\n----------------- End of Step Runmode Execution -----------------\n")
 
     impact_dict = {"IMPACT": "Impact", "NOIMPACT": "No Impact"}
     tc_timestamp = data_repository['wt_tc_timestamp']

--- a/warrior/WarriorCore/step_driver.py
+++ b/warrior/WarriorCore/step_driver.py
@@ -147,10 +147,12 @@ def execute_step(step, step_num, data_repository, system_name, kw_parallel, queu
     print_info("Teststep Description: {0}".format(step_description))
 
     if step.find("runmode") is not None and step.find("runmode").get("attempt") is not None:
-        print_info("keyword attempt: {0}".format(
+        if step.find("runmode").get("attempt") == 1:
+            print_info("----------------------Start of Runmode Execution-----------------------")
+        print_info("KEYWORD ATTEMPT: {0}".format(
             step.find("runmode").get("attempt")))
     if step.find("retry") is not None and step.find("retry").get("attempt") is not None:
-        print_info("keyword attempt: {0}".format(
+        print_info("KEYWORD ATTEMPT: {0}".format(
             step.find("retry").get("attempt")))
     kw_start_time = Utils.datetime_utils.get_current_timestamp()
     print_info("[{0}] Keyword execution starts".format(kw_start_time))
@@ -238,7 +240,6 @@ def execute_step(step, step_num, data_repository, system_name, kw_parallel, queu
 
     tc_resultsdir = data_repository['wt_resultsdir']
     tc_name = data_repository['wt_name']
-
     add_keyword_result(tc_junit_object, tc_timestamp, step_num, keyword,
                        keyword_status, kw_start_time, kw_duration,
                        kw_resultfile, impact, onerror, step_description,

--- a/warrior/WarriorCore/testcase_driver.py
+++ b/warrior/WarriorCore/testcase_driver.py
@@ -240,6 +240,7 @@ def get_steps_list(testcase_filepath):
                     copy_step = copy.deepcopy(step)
                     copy_step.find("runmode").set("value", go_next)
                     copy_step.find("runmode").set("attempt", i+1)
+                    copy_step.find("runmode").set("runmode_value", value)
                     step_list.append(copy_step)
             if retry_type is not None and retry_value > 0:
                 go_next = len(step_list) + retry_value + 1

--- a/warrior/WarriorCore/testcase_steps_execution.py
+++ b/warrior/WarriorCore/testcase_steps_execution.py
@@ -66,7 +66,6 @@ class TestCaseStepsExecutionClass(object):
         self.run_current_step = False
         self.current_triggered_action = False
         self.step_status = None
-        self.runmode_count = 0
 
     def execute_step(self, current_step_number, go_to_step_number):
         """
@@ -195,11 +194,12 @@ class TestCaseStepsExecutionClass(object):
                                kw_start_time, "0", "skipped",
                                impact_dict.get(step_impact.upper()), "N/A", step_description)
         self.data_repository['step_{}_result'.format(self.current_step_number)] = "SKIPPED"
-        # print the end of runmode execution
+        # print the end of runmode execution as the steps skip when the condition
+        # is met for RUF/RUP
         if self.current_step.find("runmode") is not None and \
            self.current_step.find("runmode").get("attempt") is not None:
             if self.current_step.find("runmode").get("attempt") == \
-               self.current_step.find("runmode").get("value")-1:
+               self.current_step.find("runmode").get("runmode_value"):
                 print_info("\n----------------- End of Step Runmode Execution -----------------\n")
         return self.current_step_number, self.go_to_step_number, "continue"
 
@@ -207,16 +207,12 @@ class TestCaseStepsExecutionClass(object):
         """
         This function will execute a runmode step
         """
-        self.runmode_count += 1
         runmode_evaluation = any([runmode == "RMT",
                                   runmode == "RUF" and step_status is True,
                                   runmode == "RUP" and step_status is False])
         if runmode_timer is not None and runmode_evaluation:
             pNote("Wait for {0}sec before the next runmode attempt ".format(runmode_timer))
             wait_for_timeout(runmode_timer)
-        # condition to print the end of runmode execution
-        if self.runmode_count == value-1:
-            print_info("\n----------------- End of Step Runmode Execution -----------------\n")
         # if runmode is 'ruf' & step_status is False, skip the repeated
         # execution of same TC step and move to next actual step
         elif runmode == "RUF" and step_status is False:

--- a/warrior/WarriorCore/testcase_steps_execution.py
+++ b/warrior/WarriorCore/testcase_steps_execution.py
@@ -195,21 +195,26 @@ class TestCaseStepsExecutionClass(object):
                                kw_start_time, "0", "skipped",
                                impact_dict.get(step_impact.upper()), "N/A", step_description)
         self.data_repository['step_{}_result'.format(self.current_step_number)] = "SKIPPED"
+        # print the end of runmode execution
+        if self.current_step.find("runmode").get("attempt") == \
+           self.current_step.find("runmode").get("value")-1:
+            print_info("\n----------------- End of Step Runmode Execution -----------------\n")
         return self.current_step_number, self.go_to_step_number, "continue"
 
     def _execute_runmode_step(self, runmode_timer, runmode, step_status, value):
         """
         This function will execute a runmode step
         """
+        self.runmode_count += 1
         runmode_evaluation = any([runmode == "RMT",
                                   runmode == "RUF" and step_status is True,
                                   runmode == "RUP" and step_status is False])
-        self.runmode_count += 1
         if runmode_timer is not None and runmode_evaluation:
             pNote("Wait for {0}sec before the next runmode attempt ".format(runmode_timer))
             wait_for_timeout(runmode_timer)
+        # condition to print the end of runmode execution
         if self.runmode_count == value-1:
-            print_info("--------------------End of Runmode Execution--------------------")
+            print_info("\n----------------- End of Step Runmode Execution -----------------\n")
         # if runmode is 'ruf' & step_status is False, skip the repeated
         # execution of same TC step and move to next actual step
         elif runmode == "RUF" and step_status is False:

--- a/warrior/WarriorCore/testcase_steps_execution.py
+++ b/warrior/WarriorCore/testcase_steps_execution.py
@@ -196,9 +196,11 @@ class TestCaseStepsExecutionClass(object):
                                impact_dict.get(step_impact.upper()), "N/A", step_description)
         self.data_repository['step_{}_result'.format(self.current_step_number)] = "SKIPPED"
         # print the end of runmode execution
-        if self.current_step.find("runmode").get("attempt") == \
-           self.current_step.find("runmode").get("value")-1:
-            print_info("\n----------------- End of Step Runmode Execution -----------------\n")
+        if self.current_step.find("runmode") is not None and \
+           self.current_step.find("runmode").get("attempt") is not None:
+            if self.current_step.find("runmode").get("attempt") == \
+               self.current_step.find("runmode").get("value")-1:
+                print_info("\n----------------- End of Step Runmode Execution -----------------\n")
         return self.current_step_number, self.go_to_step_number, "continue"
 
     def _execute_runmode_step(self, runmode_timer, runmode, step_status, value):

--- a/warrior/WarriorCore/testcase_steps_execution.py
+++ b/warrior/WarriorCore/testcase_steps_execution.py
@@ -66,6 +66,7 @@ class TestCaseStepsExecutionClass(object):
         self.run_current_step = False
         self.current_triggered_action = False
         self.step_status = None
+        self.runmode_count = 0
 
     def execute_step(self, current_step_number, go_to_step_number):
         """
@@ -79,7 +80,6 @@ class TestCaseStepsExecutionClass(object):
 
         self.go_to_step_number = go_to_step_number
         # execute steps
-
         # Decide whether or not to execute keyword
         # First decide if this step should be executed in this iteration
         if not self.go_to_step_number or self.go_to_step_number == str(self.current_step_number):
@@ -99,7 +99,6 @@ class TestCaseStepsExecutionClass(object):
             common_execution_utils.get_runmode_from_xmlfile(self.current_step)
         retry_type, retry_cond, retry_cond_value, retry_value, retry_interval = \
             common_execution_utils.get_retry_from_xmlfile(self.current_step)
-
         if runmode is not None:
             return self._execute_runmode_step(runmode_timer, runmode, self.step_status, value)
 
@@ -205,9 +204,12 @@ class TestCaseStepsExecutionClass(object):
         runmode_evaluation = any([runmode == "RMT",
                                   runmode == "RUF" and step_status is True,
                                   runmode == "RUP" and step_status is False])
+        self.runmode_count += 1
         if runmode_timer is not None and runmode_evaluation:
             pNote("Wait for {0}sec before the next runmode attempt ".format(runmode_timer))
             wait_for_timeout(runmode_timer)
+        if self.runmode_count == value-1:
+            print_info("--------------------End of Runmode Execution--------------------")
         # if runmode is 'ruf' & step_status is False, skip the repeated
         # execution of same TC step and move to next actual step
         elif runmode == "RUF" and step_status is False:

--- a/warrior/WarriorCore/testcase_steps_execution.py
+++ b/warrior/WarriorCore/testcase_steps_execution.py
@@ -199,7 +199,7 @@ class TestCaseStepsExecutionClass(object):
         if self.current_step.find("runmode") is not None and \
            self.current_step.find("runmode").get("attempt") is not None:
             if self.current_step.find("runmode").get("attempt") == \
-               self.current_step.find("runmode").get("runmode_value"):
+               self.current_step.find("runmode").get("runmode_val"):
                 print_info("\n----------------- End of Step Runmode Execution -----------------\n")
         return self.current_step_number, self.go_to_step_number, "continue"
 

--- a/warrior/WarriorCore/testsuite_driver.py
+++ b/warrior/WarriorCore/testsuite_driver.py
@@ -214,12 +214,14 @@ def get_testcase_list(testsuite_filepath):
                         copy_tc = copy.deepcopy(tc)
                         copy_tc.find("runmode").set("value", go_next)
                         copy_tc.find("runmode").set("attempt", i+1)
+                        copy_tc.find("runmode").set("runmode_value", value)
                         testcase_list.append(copy_tc)
                 # only one step in step list, append new step
                 else:
                     for i in range(0, value):
                         copy_tc = copy.deepcopy(tc)
                         copy_tc.find("runmode").set("attempt", i+1)
+                        copy_tc.find("runmode").set("runmode_value", value)
                         testcase_list.append(tc)
             if retry_type is not None and retry_value > 0:
                 if len(new_testcase_list) > 1:

--- a/warrior/WarriorCore/testsuite_driver.py
+++ b/warrior/WarriorCore/testsuite_driver.py
@@ -467,7 +467,6 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
         print_error("unexpected suite_type received...aborting execution")
         test_suite_status = False
 
-    print_info("\n")
     suite_end_time = Utils.datetime_utils.get_current_timestamp()
     print_info("[{0}] Testsuite execution completed".format(suite_end_time))
     suite_duration = Utils.datetime_utils.get_time_delta(suite_start_time)


### PR DESCRIPTION
Requirement:
1. Currently, if a step/testcase passes all the attempts and if it was set to "RUF", no print messages specifying the end of attempts is given out on the console. A message at the point where those attempts finish would be helpful to the person reading the logs later.

Fix Explanation:
1. Included the print statements at the beginning and end of runmode execution as an indication to user that the runmode execution completed all the provided attempts. 

Added the regression logs and instructions for testing in Jira.
