### PR TITLE
WAR-1828: Testsuite end result printed as PASS eventhough the testcase in that suite is not in provided path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
     fi
   - if [[ ${SELENIUM} = "yes" ]] && [[ ! -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
       pip install pyvirtualdisplay==0.2.1 ;
-      wget https://chromedriver.storage.googleapis.com/2.36/chromedriver_linux64.zip;
+      wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip;
       unzip chromedriver_linux64.zip;
       chmod +x chromedriver;
       mv chromedriver ~/bin/chromedriver;

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
     fi
   - if [[ ${SELENIUM} = "yes" ]] && [[ ! -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
       pip install pyvirtualdisplay==0.2.1 ;
-      wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip;
+      wget https://chromedriver.storage.googleapis.com/2.36/chromedriver_linux64.zip;
       unzip chromedriver_linux64.zip;
       chmod +x chromedriver;
       mv chromedriver ~/bin/chromedriver;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: python
 python: 2.7
 
+before_install:
+    - export CHROME_BIN=/usr/bin/google-chrome
+    - export DISPLAY=:99.0
+    - "sh -e /etc/init.d/xvfb start"
+    - "wget https://www.slimjet.com/chrome/download-chrome.php?file=lnx%2Fchrome64_59.0.3071.86.deb"
+    - "sudo dpkg -i *chrome64_59.0.3071.86.deb"
+
 matrix:
   include:
     - sudo: false
@@ -20,13 +27,11 @@ matrix:
       env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/selenium_project.xml SELENIUM=yes
       addons:
         firefox: "46.0"
-        chrome: stable
     - sudo: required
       dist: trusty
       env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/selenium_project.xml SELENIUM=yes SELENIUM_3=yes GECKODRIVER=yes
       addons:
         firefox: "60.0"
-        chrome: stable
     - sudo: false
       dist: trusty
       env: INSTALL=no TESTFILE=./wftests/warrior_tests/testcases/framework_tests/cond_var/pass.xml COPILOT=yes
@@ -45,7 +50,7 @@ install:
     fi
   - if [[ ${SELENIUM} = "yes" ]] && [[ ! -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
       pip install pyvirtualdisplay==0.2.1 ;
-      wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip;
+      wget https://chromedriver.storage.googleapis.com/2.32/chromedriver_linux64.zip;
       unzip chromedriver_linux64.zip;
       chmod +x chromedriver;
       mv chromedriver ~/bin/chromedriver;

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,13 @@ matrix:
       env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/selenium_project.xml SELENIUM=yes
       addons:
         firefox: "46.0"
+        chrome: stable
     - sudo: required
       dist: trusty
       env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/selenium_project.xml SELENIUM=yes SELENIUM_3=yes GECKODRIVER=yes
       addons:
         firefox: "60.0"
+        chrome: stable
     - sudo: false
       dist: trusty
       env: INSTALL=no TESTFILE=./wftests/warrior_tests/testcases/framework_tests/cond_var/pass.xml COPILOT=yes
@@ -50,7 +52,7 @@ install:
     fi
   - if [[ ${SELENIUM} = "yes" ]] && [[ ! -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
       pip install pyvirtualdisplay==0.2.1 ;
-      wget https://chromedriver.storage.googleapis.com/2.32/chromedriver_linux64.zip;
+      wget https://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip;
       unzip chromedriver_linux64.zip;
       chmod +x chromedriver;
       mv chromedriver ~/bin/chromedriver;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 language: python
 python: 2.7
 
-before_install:
-    - export CHROME_BIN=/usr/bin/google-chrome
-    - export DISPLAY=:99.0
-    - "sh -e /etc/init.d/xvfb start"
-    - "wget https://www.slimjet.com/chrome/download-chrome.php?file=lnx%2Fchrome64_59.0.3071.86.deb"
-    - "sudo dpkg -i *chrome64_59.0.3071.86.deb"
-
 matrix:
   include:
     - sudo: false
@@ -27,11 +20,13 @@ matrix:
       env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/selenium_project.xml SELENIUM=yes
       addons:
         firefox: "46.0"
+        chrome: stable
     - sudo: required
       dist: trusty
       env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/selenium_project.xml SELENIUM=yes SELENIUM_3=yes GECKODRIVER=yes
       addons:
         firefox: "60.0"
+        chrome: stable
     - sudo: false
       dist: trusty
       env: INSTALL=no TESTFILE=./wftests/warrior_tests/testcases/framework_tests/cond_var/pass.xml COPILOT=yes
@@ -50,7 +45,7 @@ install:
     fi
   - if [[ ${SELENIUM} = "yes" ]] && [[ ! -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
       pip install pyvirtualdisplay==0.2.1 ;
-      wget https://chromedriver.storage.googleapis.com/2.32/chromedriver_linux64.zip;
+      wget https://chromedriver.storage.googleapis.com/2.36/chromedriver_linux64.zip;
       unzip chromedriver_linux64.zip;
       chmod +x chromedriver;
       mv chromedriver ~/bin/chromedriver;

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,11 @@ matrix:
       env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/selenium_project.xml SELENIUM=yes
       addons:
         firefox: "46.0"
-        chrome: stable
     - sudo: required
       dist: trusty
       env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/selenium_project.xml SELENIUM=yes SELENIUM_3=yes GECKODRIVER=yes
       addons:
         firefox: "60.0"
-        chrome: stable
     - sudo: false
       dist: trusty
       env: INSTALL=no TESTFILE=./wftests/warrior_tests/testcases/framework_tests/cond_var/pass.xml COPILOT=yes
@@ -52,7 +50,7 @@ install:
     fi
   - if [[ ${SELENIUM} = "yes" ]] && [[ ! -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
       pip install pyvirtualdisplay==0.2.1 ;
-      wget https://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip;
+      wget https://chromedriver.storage.googleapis.com/2.32/chromedriver_linux64.zip;
       unzip chromedriver_linux64.zip;
       chmod +x chromedriver;
       mv chromedriver ~/bin/chromedriver;

--- a/warrior/WarriorCore/Classes/iterative_testsuite_class.py
+++ b/warrior/WarriorCore/Classes/iterative_testsuite_class.py
@@ -9,7 +9,9 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+'''
 
+"""
 Iterative testsuite:
 An iterative suite is one where the  exectype="iterative_sequential" or "iterative_parallel".
 
@@ -58,7 +60,8 @@ For the eg the execution would be as follows.
 case-1, case-2, case-3  will be executed on sys-1 sequentially,
 at the same time case-1, case-2, case-3  will be executed on sys-2 sequentially.
 So the case executions will take place in parallel on all the systems at the same time.
-'''
+
+"""
 
 from Framework.Utils import data_Utils
 from Framework.Utils.testcase_Utils import pNote

--- a/warrior/WarriorCore/Classes/iterative_testsuite_class.py
+++ b/warrior/WarriorCore/Classes/iterative_testsuite_class.py
@@ -9,9 +9,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-'''
 
-"""
 Iterative testsuite:
 An iterative suite is one where the  exectype="iterative_sequential" or "iterative_parallel".
 
@@ -60,12 +58,10 @@ For the eg the execution would be as follows.
 case-1, case-2, case-3  will be executed on sys-1 sequentially,
 at the same time case-1, case-2, case-3  will be executed on sys-2 sequentially.
 So the case executions will take place in parallel on all the systems at the same time.
+'''
 
-"""
-
-
+from Framework.Utils import data_Utils
 from Framework.Utils.testcase_Utils import pNote
-from Framework.Utils import  data_Utils
 from WarriorCore import sequential_testcase_driver, iterative_parallel_testcase_driver
 
 class IterativeTestsuite(object):
@@ -110,7 +106,7 @@ class IterativeTestsuite(object):
                                                         self.data_repository, self.from_project,
                                                         self.auto_defects, iter_ts_sys=system)
             if ts_result == 'ERROR':
-                ts_status = 'ERROR' 
+                ts_status = 'ERROR'
             else:
                 ts_status = ts_result and ts_status
         return ts_status

--- a/warrior/WarriorCore/Classes/iterative_testsuite_class.py
+++ b/warrior/WarriorCore/Classes/iterative_testsuite_class.py
@@ -109,8 +109,10 @@ class IterativeTestsuite(object):
             ts_result = sequential_testcase_driver.main(self.testcase_list, self.suite_repository,
                                                         self.data_repository, self.from_project,
                                                         self.auto_defects, iter_ts_sys=system)
-            ts_status = ts_result and ts_status
-
+            if ts_result == 'ERROR':
+                ts_status = 'ERROR' 
+            else:
+                ts_status = ts_result and ts_status
         return ts_status
 
     def execute_iterative_parallel(self):

--- a/warrior/WarriorCore/Classes/junit_class.py
+++ b/warrior/WarriorCore/Classes/junit_class.py
@@ -95,7 +95,7 @@ class Junit(object):
                 if testcase.get("timestamp") == timestamp:
                     return [testcase, testsuite, self.root]
 
-    def get_tc_with_timestamp(self, timestamp):
+    def get_tc_with_timestamp(self, timestamp=None):
         """ Get case element based on the timestamp value """
         for testsuite in list(self.root):
             for testcase in list(testsuite):

--- a/warrior/WarriorCore/Classes/junit_class.py
+++ b/warrior/WarriorCore/Classes/junit_class.py
@@ -95,7 +95,7 @@ class Junit(object):
                 if testcase.get("timestamp") == timestamp:
                     return [testcase, testsuite, self.root]
 
-    def get_tc_with_timestamp(self, timestamp=None):
+    def get_tc_with_timestamp(self, timestamp):
         """ Get case element based on the timestamp value """
         for testsuite in list(self.root):
             for testcase in list(testsuite):
@@ -205,7 +205,7 @@ class Junit(object):
         if elem.get(attr) is not None:
             elem.set(attr, str(int(elem.get(attr)) + int(value)))
 
-    def update_attr(self, attr, value, elem_type, timestamp):
+    def update_attr(self, attr, value, elem_type, timestamp=None):
         """
             update the value of an attribute based on
             element type (project, testsuite or testcase) and timestamp

--- a/warrior/WarriorCore/parallel_testcase_driver.py
+++ b/warrior/WarriorCore/parallel_testcase_driver.py
@@ -107,7 +107,8 @@ def execute_parallel_testcases(testcase_list, suite_repository,
         tc_name_list.append(result[1])
         tc_impact_list.append(result[2])
         tc_duration_list.append(result[3])
-        tc_junit_list.append(result[4])
+        if result[0] != 'ERROR':         
+            tc_junit_list.append(result[4])
     
     # parallel testcases generate multiple testcase junit result files
     # each files log the result for one testcase and not intergrated

--- a/warrior/WarriorCore/parallel_testcase_driver.py
+++ b/warrior/WarriorCore/parallel_testcase_driver.py
@@ -107,7 +107,7 @@ def execute_parallel_testcases(testcase_list, suite_repository,
         tc_name_list.append(result[1])
         tc_impact_list.append(result[2])
         tc_duration_list.append(result[3])
-        if result[0] != 'ERROR':         
+        if len(result) > 4:         
             tc_junit_list.append(result[4])
     
     # parallel testcases generate multiple testcase junit result files

--- a/warrior/WarriorCore/parallel_testcase_driver.py
+++ b/warrior/WarriorCore/parallel_testcase_driver.py
@@ -66,7 +66,7 @@ def execute_parallel_testcases(testcase_list, suite_repository,
         data_repository['wt_tc_impact'] = tc_impact
 
         # instead of using args_list, we need to use an ordered dict
-        # for tc args because intially q will be none and 
+        # for tc args because intially q will be none and
         # we need to cange it after creating a new q
         # then we need to maintain the position of arguments
         # before calling the testcase driver main function.
@@ -81,8 +81,7 @@ def execute_parallel_testcases(testcase_list, suite_repository,
                                     ("tc_onError_action", tc_onError_action),
                                     ("iter_ts_sys", iter_ts_sys),
                                     ("output_q", output_q),
-                                    ("jiraproj", jiraproj)
-                                    ])
+                                    ("jiraproj", jiraproj)])
 
         process, jobs_list, output_q = create_and_start_process_with_queue(target_module,
                                                                            tc_args_dict,

--- a/warrior/WarriorCore/sequential_testcase_driver.py
+++ b/warrior/WarriorCore/sequential_testcase_driver.py
@@ -69,6 +69,7 @@ def execute_sequential_testcases(testcase_list, suite_repository,
     suite_error_action = suite_repository['def_on_error_action']
     suite_error_value = suite_repository['def_on_error_value']
     testsuite_dir = os.path.dirname(testsuite_filepath)
+    data_repository['wt_tc_timestamp'] = None
 
     errors = 0
     skipped = 0
@@ -231,13 +232,12 @@ def execute_sequential_testcases(testcase_list, suite_repository,
         else:
             onerror = "Goto:" + str(goto_tc_num)
 
-        if tc_status != 'ERROR':     
-            data_repository['wt_junit_object'].update_attr(
-                            "impact", impact_dict.get(tc_impact.upper()), "tc",
-                            data_repository['wt_tc_timestamp'])
-            data_repository['wt_junit_object'].update_attr(
-                            "onerror", onerror, "tc",
-                            data_repository['wt_tc_timestamp'])
+        data_repository['wt_junit_object'].update_attr(
+                        "impact", impact_dict.get(tc_impact.upper()), "tc",
+                        data_repository['wt_tc_timestamp'])
+        data_repository['wt_junit_object'].update_attr(
+                        "onerror", onerror, "tc",
+                        data_repository['wt_tc_timestamp'])
 
         tc_status_list.append(tc_status)
         tc_duration_list.append(tc_duration)

--- a/warrior/WarriorCore/sequential_testcase_driver.py
+++ b/warrior/WarriorCore/sequential_testcase_driver.py
@@ -230,12 +230,14 @@ def execute_sequential_testcases(testcase_list, suite_repository,
             onerror = "Abort"
         else:
             onerror = "Goto:" + str(goto_tc_num)
-        data_repository['wt_junit_object'].update_attr(
-                        "impact", impact_dict.get(tc_impact.upper()), "tc",
-                        data_repository['wt_tc_timestamp'])
-        data_repository['wt_junit_object'].update_attr(
-                        "onerror", onerror, "tc",
-                        data_repository['wt_tc_timestamp'])
+
+        if tc_status != 'ERROR':     
+            data_repository['wt_junit_object'].update_attr(
+                            "impact", impact_dict.get(tc_impact.upper()), "tc",
+                            data_repository['wt_tc_timestamp'])
+            data_repository['wt_junit_object'].update_attr(
+                            "onerror", onerror, "tc",
+                            data_repository['wt_tc_timestamp'])
 
         tc_status_list.append(tc_status)
         tc_duration_list.append(tc_duration)

--- a/warrior/WarriorCore/sequential_testcase_driver.py
+++ b/warrior/WarriorCore/sequential_testcase_driver.py
@@ -231,14 +231,12 @@ def execute_sequential_testcases(testcase_list, suite_repository,
             onerror = "Abort"
         else:
             onerror = "Goto:" + str(goto_tc_num)
-
         data_repository['wt_junit_object'].update_attr(
                         "impact", impact_dict.get(tc_impact.upper()), "tc",
                         data_repository['wt_tc_timestamp'])
         data_repository['wt_junit_object'].update_attr(
                         "onerror", onerror, "tc",
                         data_repository['wt_tc_timestamp'])
-
         tc_status_list.append(tc_status)
         tc_duration_list.append(tc_duration)
 

--- a/warrior/WarriorCore/sequential_testsuite_driver.py
+++ b/warrior/WarriorCore/sequential_testsuite_driver.py
@@ -43,8 +43,9 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
     project_dir = os.path.dirname(project_filepath)
     wp_results_execdir = project_repository['wp_results_execdir']
     wp_logs_execdir = project_repository['wp_logs_execdir']
-    project_error_value = project_repository['def_on_error_value']
+    project_error_value = project_repository['def_on_error_value']i
 
+    data_repository['wt_ts_timestamp'] = None
     jiraproj = data_repository['jiraproj']
     pj_junit_object = data_repository['wt_junit_object']
 

--- a/warrior/WarriorCore/sequential_testsuite_driver.py
+++ b/warrior/WarriorCore/sequential_testsuite_driver.py
@@ -43,7 +43,7 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
     project_dir = os.path.dirname(project_filepath)
     wp_results_execdir = project_repository['wp_results_execdir']
     wp_logs_execdir = project_repository['wp_logs_execdir']
-    project_error_value = project_repository['def_on_error_value']i
+    project_error_value = project_repository['def_on_error_value']
 
     data_repository['wt_ts_timestamp'] = None
     jiraproj = data_repository['jiraproj']

--- a/warrior/WarriorCore/sequential_testsuite_driver.py
+++ b/warrior/WarriorCore/sequential_testsuite_driver.py
@@ -44,7 +44,6 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
     wp_results_execdir = project_repository['wp_results_execdir']
     wp_logs_execdir = project_repository['wp_logs_execdir']
     project_error_value = project_repository['def_on_error_value']
-
     data_repository['wt_ts_timestamp'] = None
     jiraproj = data_repository['jiraproj']
     pj_junit_object = data_repository['wt_junit_object']

--- a/wftests/warrior_tests/config_files/selenium_func_tests/ec_verify_presence_of_elements.json
+++ b/wftests/warrior_tests/config_files/selenium_func_tests/ec_verify_presence_of_elements.json
@@ -1,3 +1,3 @@
 {
-  "text_to_verify": [{"verification_text": "Google Sear,Sign in"}]
+  "text_to_verify": [{"verification_text": "Sign in"}]
 }

--- a/wftests/warrior_tests/config_files/selenium_func_tests/ec_warrior_selenium_Config.json
+++ b/wftests/warrior_tests/config_files/selenium_func_tests/ec_warrior_selenium_Config.json
@@ -2,7 +2,7 @@
   "search_box":
   [
   	{"name":"q"},
-  	{"xpath" : "//*[@id='lst-ib']"}
+  	{"xpath" : "//*[@title='Search']"}
 
   ],
 

--- a/wftests/warrior_tests/projects/pj_framework_tests.xml
+++ b/wftests/warrior_tests/projects/pj_framework_tests.xml
@@ -22,5 +22,29 @@
             <onError action="next" value=""/>
             <impact>impact</impact>
         </Testsuite>
+        <Testsuite>
+            <path>../suites/framework_tests/invalid_path_tests/ts_sequential.xml</path>
+            <Execute ExecType="Yes"/>
+            <onError action="next" value=""/>
+            <impact>noimpact</impact>
+        </Testsuite>
+        <Testsuite>
+            <path>../suites/framework_tests/invalid_path_tests/ts_parallel.xml</path>
+            <Execute ExecType="Yes"/>
+            <onError action="next" value=""/>
+            <impact>noimpact</impact>
+        </Testsuite>
+        <Testsuite>
+            <path>../suites/framework_tests/invalid_path_tests/ts_iter_seq.xml</path>
+            <Execute ExecType="Yes"/>
+            <onError action="next" value=""/>
+            <impact>noimpact</impact>
+        </Testsuite>
+        <Testsuite>
+            <path>../suites/framework_tests/invalid_path_tests/ts_iter_par.xml</path>
+            <Execute ExecType="Yes"/>
+            <onError action="next" value=""/>
+            <impact>noimpact</impact>
+        </Testsuite>
     </Testsuites>
 </Project>

--- a/wftests/warrior_tests/projects/selenium_project.xml
+++ b/wftests/warrior_tests/projects/selenium_project.xml
@@ -3,9 +3,8 @@
 	<Details>
 		<Name>selenium_project</Name>
 		<Title>selenium functional tests</Title>
-		<Engineer>Sanika Kulkarni</Engineer>
-		<Date>06/21/2016</Date>
-		<Time>16:14:45</Time>
+		<Engineer>Sayyeda Farheen</Engineer>
+		<Date>07/25/2018</Date>
 		<default_onError action="next"/>
 	</Details>
 	<Testsuites>

--- a/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_iter_par.xml
+++ b/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_iter_par.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_iter_seq</Name>
+                <Title>TS with iterative testcases(datafile) with sequential testcase execution</Title>
+                <Engineer>ka</Engineer>
+                <Date>05/23/2017</Date>
+                <Time>14:11:26</Time>
+                <type exectype="iterative_parallel"/>
+                <State/>
+                <default_onError action="next"/>
+                <Resultsdir/>
+                <InputDataFile>../../../data/framework_tests/data_iter_ts.xml</InputDataFile>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>invalid_testcase_path</path>
+                        <context>positive</context>
+                        <InputDataFile/>
+                        <runtype>sequential_keywords</runtype>
+                        <impact>impact</impact>
+                </Testcase>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/iter_execution/tc_seq_1.xml</path>
+                        <context>positive</context>
+                        <InputDataFile/>
+                        <runtype>sequential_keywords</runtype>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_iter_par.xml
+++ b/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_iter_par.xml
@@ -2,10 +2,9 @@
 <TestSuite>
         <Details>
                 <Name>ts_iter_seq</Name>
-                <Title>TS with iterative testcases(datafile) with sequential testcase execution</Title>
-                <Engineer>ka</Engineer>
-                <Date>05/23/2017</Date>
-                <Time>14:11:26</Time>
+		            <Title>Validate tc status on giving invalid path for iterative parallel testcases</Title>
+		            <Engineer>Sayyeda Farheen</Engineer>
+		            <Date>08/23/2018</Date>
                 <type exectype="iterative_parallel"/>
                 <State/>
                 <default_onError action="next"/>

--- a/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_iter_par.xml
+++ b/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_iter_par.xml
@@ -2,9 +2,9 @@
 <TestSuite>
         <Details>
                 <Name>ts_iter_seq</Name>
-		            <Title>Validate tc status on giving invalid path for iterative parallel testcases</Title>
-		            <Engineer>Sayyeda Farheen</Engineer>
-		            <Date>08/23/2018</Date>
+                <Title>Validate tc status on giving invalid path for iterative parallel testcases</Title>
+                <Engineer>Sayyeda Farheen</Engineer>
+                <Date>08/23/2018</Date>
                 <type exectype="iterative_parallel"/>
                 <State/>
                 <default_onError action="next"/>

--- a/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_iter_seq.xml
+++ b/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_iter_seq.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_iter_seq</Name>
+                <Title>TS with iterative testcases(datafile) with sequential testcase execution</Title>
+                <Engineer>ka</Engineer>
+                <Date>05/23/2017</Date>
+                <Time>14:11:26</Time>
+                <type exectype="iterative_sequential"/>
+                <State/>
+                <default_onError action="next"/>
+                <Resultsdir/>
+                <InputDataFile>../../../data/framework_tests/data_iter_ts.xml</InputDataFile>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>invalid_testcase_path</path>
+                        <context>positive</context>
+                        <InputDataFile/>
+                        <runtype>sequential_keywords</runtype>
+                        <impact>impact</impact>
+                </Testcase>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/iter_execution/tc_seq_1.xml</path>
+                        <context>positive</context>
+                        <InputDataFile/>
+                        <runtype>sequential_keywords</runtype>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_iter_seq.xml
+++ b/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_iter_seq.xml
@@ -3,8 +3,8 @@
         <Details>
                 <Name>ts_iter_seq</Name>
                 <Title>Validate tc status on giving invalid path for iterative sequential testcases</Title>
-		            <Engineer>Sayyeda Farheen</Engineer>
-		            <Date>08/23/2018</Date>
+                <Engineer>Sayyeda Farheen</Engineer>
+                <Date>08/23/2018</Date>
                 <type exectype="iterative_sequential"/>
                 <State/>
                 <default_onError action="next"/>

--- a/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_iter_seq.xml
+++ b/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_iter_seq.xml
@@ -2,10 +2,9 @@
 <TestSuite>
         <Details>
                 <Name>ts_iter_seq</Name>
-                <Title>TS with iterative testcases(datafile) with sequential testcase execution</Title>
-                <Engineer>ka</Engineer>
-                <Date>05/23/2017</Date>
-                <Time>14:11:26</Time>
+                <Title>Validate tc status on giving invalid path for iterative sequential testcases</Title>
+		            <Engineer>Sayyeda Farheen</Engineer>
+		            <Date>08/23/2018</Date>
                 <type exectype="iterative_sequential"/>
                 <State/>
                 <default_onError action="next"/>

--- a/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_parallel.xml
+++ b/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_parallel.xml
@@ -2,9 +2,9 @@
 <TestSuite>
 	<Details>
 		<Name>cond_var</Name>
-		<Title>Test tc status on giving invalid path for parallel testcases</Title>
+		<Title>Validate tc status on giving invalid path for parallel testcases</Title>
 		<Engineer>Sayyeda Farheen</Engineer>
-		<Date>08/21/2018</Date>
+		<Date>08/23/2018</Date>
 		<type exectype="parallel_testcases"/>
 		<State/>
 		<default_onError action="next"/>

--- a/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_parallel.xml
+++ b/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_parallel.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+<TestSuite>
+	<Details>
+		<Name>cond_var</Name>
+		<Title>Test tc status on giving invalid path for parallel testcases</Title>
+		<Engineer>Sayyeda Farheen</Engineer>
+		<Date>08/21/2018</Date>
+		<type exectype="parallel_testcases"/>
+		<State/>
+		<default_onError action="next"/>
+		<Resultsdir/>
+		<IDF/>
+	</Details>
+	<Requirements>
+		<Requirement/>
+	</Requirements>
+	<Testcases>
+		<Testcase>
+			<path>../../../testcases/framework_tests/cond_var/pass.xml</path>
+			<context>positive</context>
+			<runtype>parallel_keywords</runtype>
+			<impact>impact</impact>
+		</Testcase>
+		<Testcase>
+			<path>invalid_testcase_path</path>
+			<context>positive</context>
+			<runtype>parallel_keywords</runtype>
+			<impact>impact</impact>
+		</Testcase>
+	</Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_sequential.xml
+++ b/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_sequential.xml
@@ -2,9 +2,9 @@
 <TestSuite>
 	<Details>
 		<Name>cond_var</Name>
-		<Title>Test tc status on giving invalid path for sequential testcases</Title>
+		<Title>Validate tc status on giving invalid path for sequential testcases</Title>
 		<Engineer>Sayyeda Farheen</Engineer>
-		<Date>08/21/2018</Date>
+		<Date>08/23/2018</Date>
 		<type exectype="sequential_testcases"/>
 		<State/>
 		<default_onError action="next"/>

--- a/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_sequential.xml
+++ b/wftests/warrior_tests/suites/framework_tests/invalid_path_tests/ts_sequential.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+<TestSuite>
+	<Details>
+		<Name>cond_var</Name>
+		<Title>Test tc status on giving invalid path for sequential testcases</Title>
+		<Engineer>Sayyeda Farheen</Engineer>
+		<Date>08/21/2018</Date>
+		<type exectype="sequential_testcases"/>
+		<State/>
+		<default_onError action="next"/>
+		<Resultsdir/>
+		<IDF/>
+	</Details>
+	<Requirements>
+		<Requirement/>
+	</Requirements>
+	<Testcases>
+		<Testcase>
+			<path>../../../testcases/framework_tests/cond_var/pass.xml</path>
+			<context>positive</context>
+			<runtype>sequential_keywords</runtype>
+			<impact>impact</impact>
+		</Testcase>
+		<Testcase>
+			<path>invalid_testcase_path</path>
+			<context>positive</context>
+			<runtype>sequential_keywords</runtype>
+			<impact>impact</impact>
+		</Testcase>
+	</Testcases>
+</TestSuite>


### PR DESCRIPTION
Issue:
------
TestSuite end results are printed as Passed/Failed for an invalid test case path.

Expected Behavior:
---------------------
TestSuite results ahould be displayed as 'ERROR' on executing a test case with an invalid path for all testcase types:
1. sequential testcases 
2. parallel testcases
3. iterative parallel
4. iterative sequential

Fix:
---
1. Initialized timestamp for testcase[wt_tc_timestamp] and testsuite[wt_ts_timestamp] to 'None' in testcase and testsuite driver files respectively as these details do not get updated on testcase/testsuite path failure cases which in turn was throwing 'keyError'.
2. Defaulting timestamp attribute as 'None' in update_attr in junit_class file.
3. Setting the testsuite status as 'Error' if error value is received in iterative testsuite driver file as
4. Since no junit object is created for invalid path, added a check to update the juint_list only if there is an object created in the output_q in parallel_testcase driver.

Added testcases to verify the functionality.