### PR TITLE
WAR-599: As a user, I need a way to state the final step status when running a step with RUP

### DIFF
--- a/warrior/WarriorCore/common_execution_utils.py
+++ b/warrior/WarriorCore/common_execution_utils.py
@@ -236,39 +236,44 @@ def compute_status(element, status_list, impact_list, status, impact):
     if runmode is None:
         status_list.append(status)
         impact_list.append(impact)
-    elif runmode.upper() == "RMT":
-        status_list.append(status)
-        impact_list.append(impact)
-    elif runmode.upper() == "RUP":
-        if element.find('runmode').get('status') is None or \
-           element.find('runmode').get('status') == "":
+    else:
+        if element.find('runmode').get('status') not in [None, '', 'last_instance', 'expected']:
+            print_warning("Unsupported value for status. Please provide a valid value. "
+                          "Using the Default value for execution")
+            element.find('runmode').set('status', '')
+        if runmode.upper() == "RMT":
             status_list.append(status)
             impact_list.append(impact)
-        elif element.find('runmode').get('status') == 'last_instance' or \
-                element.find('runmode').get('status') == 'expected':
-            if status is True or \
-                (element.find('runmode').get('attempt') ==
-                 element.find('runmode').get('runmode_val')):
+        elif runmode.upper() == "RUP":
+            if element.find('runmode').get('status') is None or \
+                 element.find('runmode').get('status') == '':
                 status_list.append(status)
                 impact_list.append(impact)
-    elif runmode.upper() == "RUF":
-        if element.find('runmode').get('status') is None or \
-           element.find('runmode').get('status') == "":
-            status_list.append(status)
-            impact_list.append(impact)
-        elif element.find('runmode').get('status') == 'last_instance':
-            if status is False or \
-                (element.find('runmode').get('attempt') ==
-                 element.find('runmode').get('runmode_val')):
+            elif element.find('runmode').get('status') == 'last_instance' or \
+                    element.find('runmode').get('status') == 'expected':
+                if status is True or \
+                    (element.find('runmode').get('attempt') ==
+                     element.find('runmode').get('runmode_val')):
+                    status_list.append(status)
+                    impact_list.append(impact)
+        elif runmode.upper() == "RUF":
+            if element.find('runmode').get('status') is None or \
+                 element.find('runmode').get('status') == "":
                 status_list.append(status)
                 impact_list.append(impact)
-        elif element.find('runmode').get('status') == 'expected':
-            if status is False:
-                status_list.append(True)
-                impact_list.append(impact)
-            elif status is not False and \
-                (element.find('runmode').get('attempt') ==
-                 element.find('runmode').get('runmode_val')):
-                status_list.append(False)
-                impact_list.append(impact)
+            elif element.find('runmode').get('status') == 'last_instance':
+                if status is False or \
+                    (element.find('runmode').get('attempt') ==
+                     element.find('runmode').get('runmode_val')):
+                    status_list.append(status)
+                    impact_list.append(impact)
+            elif element.find('runmode').get('status') == 'expected':
+                if status is False:
+                    status_list.append(True)
+                    impact_list.append(impact)
+                elif status is not False and \
+                    (element.find('runmode').get('attempt') ==
+                     element.find('runmode').get('runmode_val')):
+                    status_list.append(False)
+                    impact_list.append(impact)
     return status_list, impact_list

--- a/warrior/WarriorCore/common_execution_utils.py
+++ b/warrior/WarriorCore/common_execution_utils.py
@@ -278,7 +278,7 @@ def compute_status(element, status_list, impact_list, status, impact):
                     impact_list.append(impact)
     return status_list, impact_list
 
-  
+
 def compute_runmode_status(global_status_list, runmode, global_xml):
     """ Computes the status of runmode execution when runmode is provided in
        global level (Details section)
@@ -317,4 +317,3 @@ def compute_runmode_status(global_status_list, runmode, global_xml):
         else:
             status_value = global_status_list.pop()
     return status_value
-

--- a/warrior/WarriorCore/common_execution_utils.py
+++ b/warrior/WarriorCore/common_execution_utils.py
@@ -236,20 +236,20 @@ def compute_status(element, status_list, impact_list, status, impact):
         status_list.append(status)
         impact_list.append(impact)
     elif runmode.upper() == "RMT":
-            status_list.append(status)
-            impact_list.append(impact)
+        status_list.append(status)
+        impact_list.append(impact)
     elif runmode.upper() == "RUP":
         if element.find('runmode').get('status') is None or \
            element.find('runmode').get('status') == "":
-                status_list.append(status)
-                impact_list.append(impact)
+            status_list.append(status)
+            impact_list.append(impact)
         elif element.find('runmode').get('status') == 'last_instance' or \
                 element.find('runmode').get('status') == 'expected':
             if status is True or \
                 (element.find('runmode').get('attempt') ==
                  element.find('runmode').get('runmode_value')):
-                    status_list.append(status)
-                    impact_list.append(impact)
+                status_list.append(status)
+                impact_list.append(impact)
     elif runmode.upper() == "RUF":
         if element.find('runmode').get('status') is None or \
            element.find('runmode').get('status') == "":
@@ -259,8 +259,8 @@ def compute_status(element, status_list, impact_list, status, impact):
             if status is False or \
                 (element.find('runmode').get('attempt') ==
                  element.find('runmode').get('runmode_value')):
-                    status_list.append(status)
-                    impact_list.append(impact)
+                status_list.append(status)
+                impact_list.append(impact)
         elif element.find('runmode').get('status') == 'expected':
             if status is False:
                 status_list.append(True)
@@ -268,6 +268,6 @@ def compute_status(element, status_list, impact_list, status, impact):
             elif status is not False and \
                 (element.find('runmode').get('attempt') ==
                  element.find('runmode').get('runmode_value')):
-                    status_list.append(False)
-                    impact_list.append(impact)
+                status_list.append(False)
+                impact_list.append(impact)
     return status_list, impact_list

--- a/warrior/WarriorCore/common_execution_utils.py
+++ b/warrior/WarriorCore/common_execution_utils.py
@@ -40,6 +40,7 @@ def append_step_list(step_list, step, value, go_next, mode, tag):
         copy_step = copy.deepcopy(step)
         copy_step.find(mode).set(tag, go_next)
         copy_step.find(mode).set("attempt", i + 1)
+        copy_step.find(mode).set(mode+"_val", value)
         step_list.append(copy_step)
     return step_list
 
@@ -247,7 +248,7 @@ def compute_status(element, status_list, impact_list, status, impact):
                 element.find('runmode').get('status') == 'expected':
             if status is True or \
                 (element.find('runmode').get('attempt') ==
-                 element.find('runmode').get('runmode_value')):
+                 element.find('runmode').get('runmode_val')):
                 status_list.append(status)
                 impact_list.append(impact)
     elif runmode.upper() == "RUF":
@@ -258,7 +259,7 @@ def compute_status(element, status_list, impact_list, status, impact):
         elif element.find('runmode').get('status') == 'last_instance':
             if status is False or \
                 (element.find('runmode').get('attempt') ==
-                 element.find('runmode').get('runmode_value')):
+                 element.find('runmode').get('runmode_val')):
                 status_list.append(status)
                 impact_list.append(impact)
         elif element.find('runmode').get('status') == 'expected':
@@ -267,7 +268,7 @@ def compute_status(element, status_list, impact_list, status, impact):
                 impact_list.append(impact)
             elif status is not False and \
                 (element.find('runmode').get('attempt') ==
-                 element.find('runmode').get('runmode_value')):
+                 element.find('runmode').get('runmode_val')):
                 status_list.append(False)
                 impact_list.append(impact)
     return status_list, impact_list

--- a/warrior/WarriorCore/project_driver.py
+++ b/warrior/WarriorCore/project_driver.py
@@ -160,6 +160,7 @@ def get_testsuite_list(project_filepath):
                     copy_ts = copy.deepcopy(ts)
                     copy_ts.find("runmode").set("value", go_next)
                     copy_ts.find("runmode").set("attempt", i+1)
+                    copy_ts.find("runmode").set("runmode_value", value)
                     testsuite_list.append(copy_ts)
             if retry_type is not None and retry_value > 0:
                 if len(new_testsuite_list) > 1:

--- a/warrior/WarriorCore/project_driver.py
+++ b/warrior/WarriorCore/project_driver.py
@@ -60,9 +60,9 @@ def get_project_details(project_filepath, res_startdir, logs_startdir, data_repo
     if def_on_error_value is None or def_on_error_value is False:
         def_on_error_value = None
 
-    if data_repository.has_key('ow_resultdir'):
+    if 'ow_resultdir' in data_repository:
         res_startdir = data_repository['ow_resultdir']
-    if data_repository.has_key('ow_logdir'):
+    if 'ow_logdir' in data_repository:
         logs_startdir = data_repository['ow_logdir']
 
     efile_obj = execution_files_class.ExecFilesClass(project_filepath,
@@ -93,7 +93,7 @@ def get_project_details(project_filepath, res_startdir, logs_startdir, data_repo
 
     return project_repository
 
-  
+
 def execute_project(project_filepath, auto_defects, jiraproj, res_startdir, logs_startdir,
                     data_repository):
     """

--- a/warrior/WarriorCore/sequential_testcase_driver.py
+++ b/warrior/WarriorCore/sequential_testcase_driver.py
@@ -110,12 +110,12 @@ def execute_sequential_testcases(testcase_list, suite_repository,
         data_repository['wt_tc_impact'] = tc_impact
         if testcase.find("runmode") is not None and \
            testcase.find("runmode").get("attempt") is not None:
-            print_info("testcase attempt: {0}".format(
-                                testcase.find("runmode").get("attempt")))
+            print_info("testcase attempt: {0}".format(testcase.find("runmode")
+                                                      .get("attempt")))
         if testcase.find("retry") is not None and \
            testcase.find("retry").get("attempt") is not None:
-            print_info("testcase attempt: {0}".format(
-                                testcase.find("retry").get("attempt")))
+            print_info("testcase attempt: {0}".format(testcase.find("retry")
+                                                      .get("attempt")))
 
         if Utils.file_Utils.fileExists(tc_path) or action is False:
             tc_name = Utils.file_Utils.getFileName(tc_path)

--- a/warrior/WarriorCore/sequential_testcase_driver.py
+++ b/warrior/WarriorCore/sequential_testcase_driver.py
@@ -35,53 +35,6 @@ def update_suite_attribs(junit_resultfile, errors, skipped,
                                                    str(skipped), str(tests), str(failures), time)
 
 
-def compute_status(tc_status, tc_impact, testcase, tc_status_list, tc_impact_list):
-    """
-    This function computes the overall status
-    """
-    runmode, _, _ = \
-        common_execution_utils.get_runmode_from_xmlfile(testcase)
-    if runmode is None:
-        tc_status_list.append(tc_status)
-        tc_impact_list.append(tc_impact)
-    elif runmode.upper() == "RMT":
-        tc_status_list.append(tc_status)
-        tc_impact_list.append(tc_impact)
-    elif runmode.upper() == "RUP":
-        if testcase.find('runmode').get('status') is None or \
-           testcase.find('runmode').get('status') == "":
-            tc_status_list.append(tc_status)
-            tc_impact_list.append(tc_impact)
-        elif testcase.find('runmode').get('status') == 'last_instance' or \
-             testcase.find('runmode').get('status') == 'expected':
-                if tc_status is True or \
-                  (testcase.find('runmode').get('attempt') ==
-                   testcase.find('runmode').get('runmode_value')):
-                    tc_status_list.append(tc_status)
-                    tc_impact_list.append(tc_impact)
-    elif runmode.upper() == "RUF":
-        if testcase.find('runmode').get('status') is None or \
-           testcase.find('runmode').get('status') == "":
-            tc_status_list.append(tc_status)
-            tc_impact_list.append(tc_impact)
-        elif testcase.find('runmode').get('status') == 'last_instance':
-            if tc_status is False or \
-              (testcase.find('runmode').get('attempt') ==
-               testcase.find('runmode').get('runmode_value')):
-                    tc_status_list.append(tc_status)
-                    tc_impact_list.append(tc_impact)
-        elif testcase.find('runmode').get('status') == 'expected':
-            if tc_status is False:
-                tc_status_list.append(True)
-                tc_impact_list.append(tc_impact)
-            elif tc_status is not False and \
-                (testcase.find('runmode').get('attempt') ==
-                 testcase.find('runmode').get('runmode_value')):
-                    tc_status_list.append(False)
-                    tc_impact_list.append(tc_impact)
-    return tc_status_list, tc_impact_list
-
-
 def execute_sequential_testcases(testcase_list, suite_repository,
                                  data_repository, from_project, auto_defects,
                                  iter_ts_sys, tc_parallel, queue, ts_iter):
@@ -283,8 +236,10 @@ def execute_sequential_testcases(testcase_list, suite_repository,
                         "onerror", onerror, "tc",
                         data_repository['wt_tc_timestamp'])
 
-        tc_status_list, tc_impact_list = compute_status(tc_status, tc_impact,
-                                                        testcase, tc_status_list, tc_impact_list)
+        tc_status_list, tc_impact_list = \
+            common_execution_utils.compute_status(testcase, tc_status_list,
+                                                  tc_status_list,
+                                                  tc_status, tc_impact)
         tc_duration_list.append(tc_duration)
 
         string_status = {"TRUE": "PASS", "FALSE": "FAIL", "ERROR": "ERROR",

--- a/warrior/WarriorCore/sequential_testcase_driver.py
+++ b/warrior/WarriorCore/sequential_testcase_driver.py
@@ -238,7 +238,7 @@ def execute_sequential_testcases(testcase_list, suite_repository,
 
         tc_status_list, tc_impact_list = \
             common_execution_utils.compute_status(testcase, tc_status_list,
-                                                  tc_status_list,
+                                                  tc_impact_list,
                                                   tc_status, tc_impact)
         tc_duration_list.append(tc_duration)
 

--- a/warrior/WarriorCore/sequential_testsuite_driver.py
+++ b/warrior/WarriorCore/sequential_testsuite_driver.py
@@ -28,54 +28,6 @@ from Framework.Utils.testcase_Utils import pNote
 the suites of a project in sequential order"""
 
 
-def compute_status(testsuite_status, testsuite_impact, testsuite, ts_status_list,
-                   ts_impact_list):
-    """
-    This function computes the overall status
-    """
-    runmode, _, _ = \
-        common_execution_utils.get_runmode_from_xmlfile(testsuite)
-    if runmode is None:
-        ts_status_list.append(testsuite_status)
-        ts_impact_list.append(testsuite_impact)
-    elif runmode.upper() == "RMT":
-        ts_status_list.append(testsuite_status)
-        ts_impact_list.append(testsuite_impact)
-    elif runmode.upper() == "RUP":
-        if testsuite.find('runmode').get('status') is None or \
-           testsuite.find('runmode').get('status') == "":
-            ts_status_list.append(testsuite_status)
-            ts_impact_list.append(testsuite_impact)
-        elif testsuite.find('runmode').get('status') == 'last_instance' or \
-             testsuite.find('runmode').get('status') == 'expected':
-                if testsuite_status is True or \
-                  (testsuite.find('runmode').get('attempt') ==
-                   testsuite.find('runmode').get('runmode_value')):
-                    ts_status_list.append(testsuite_status)
-                    ts_impact_list.append(testsuite_impact)
-    elif runmode.upper() == "RUF":
-        if testsuite.find('runmode').get('status') is None or \
-           testsuite.find('runmode').get('status') == "":
-            ts_status_list.append(testsuite_status)
-            ts_impact_list.append(testsuite_impact)
-        elif testsuite.find('runmode').get('status') == 'last_instance':
-            if testsuite_status is False or \
-              (testsuite.find('runmode').get('attempt') ==
-               testsuite.find('runmode').get('runmode_value')):
-                    ts_status_list.append(testsuite_status)
-                    ts_impact_list.append(testsuite_impact)
-        elif testsuite.find('runmode').get('status') == 'expected':
-            if testsuite_status is False:
-                ts_status_list.append(True)
-                ts_impact_list.append(testsuite_impact)
-            elif testsuite_status is not False and \
-                (testsuite.find('runmode').get('attempt') ==
-                 testsuite.find('runmode').get('runmode_value')):
-                    ts_status_list.append(False)
-                    ts_impact_list.append(testsuite_impact)
-    return ts_status_list, ts_impact_list
-
-
 def execute_sequential_testsuites(testsuite_list, project_repository,
                                   data_repository, auto_defects):
     """ Executes suites in a project sequentially """
@@ -195,8 +147,10 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
             print_error("unexpected testsuite status, default to exception")
             data_repository['testsuite_%d_result' % suite_cntr] = "ERROR"
 
-        ts_status_list, ts_impact_list = compute_status(testsuite_status, testsuite_impact,
-                                                        testsuite, ts_status_list, ts_impact_list)
+        ts_status_list, ts_impact_list = \
+            common_execution_utils.compute_status(testsuite, ts_status_list,
+                                                  ts_impact_list,
+                                                  testsuite_status, testsuite_impact)
         if testsuite_impact.upper() == 'IMPACT':
             msg = "Status of the executed test suite impacts Project result"
         elif testsuite_impact.upper() == 'NOIMPACT':

--- a/warrior/WarriorCore/sequential_testsuite_driver.py
+++ b/warrior/WarriorCore/sequential_testsuite_driver.py
@@ -11,10 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 
-# !/usr/bin/python
-"""This is sequential suite driver which is used to execute
-the suites of a project in sequential order"""
-
 import os
 import time
 import traceback
@@ -26,6 +22,10 @@ from WarriorCore import exec_type_driver
 import WarriorCore.testsuite_driver as testsuite_driver
 import WarriorCore.onerror_driver as onerror_driver
 from Framework.Utils.testcase_Utils import pNote
+
+# !/usr/bin/python
+"""This is sequential suite driver which is used to execute
+the suites of a project in sequential order"""
 
 
 def compute_status(testsuite_status, testsuite_impact, testsuite, ts_status_list,
@@ -102,7 +102,8 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
 
         testsuite_rel_path = testsuite_utils.get_path_from_xmlfile(testsuite)
         if testsuite_rel_path is not None:
-            testsuite_path = Utils.file_Utils.getAbsPath(testsuite_rel_path, project_dir)
+            testsuite_path = Utils.file_Utils.getAbsPath(testsuite_rel_path,
+                                                         project_dir)
         else:
             testsuite_path = str(testsuite_rel_path)
         print_info("\n")
@@ -228,7 +229,8 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
                         condition_met = True
                         pNote("Wait for {0}sec before retrying".format(retry_interval))
                         pNote("The given condition '{0}' matches the expected"
-                              "value '{1}'".format(data_repository[retry_cond], retry_cond_value))
+                              "value '{1}'".format(data_repository[retry_cond],
+                                                   retry_cond_value))
                         time.sleep(int(retry_interval))
                     else:
                         condition_met = False

--- a/warrior/WarriorCore/sequential_testsuite_driver.py
+++ b/warrior/WarriorCore/sequential_testsuite_driver.py
@@ -28,6 +28,54 @@ import WarriorCore.onerror_driver as onerror_driver
 from Framework.Utils.testcase_Utils import pNote
 
 
+def compute_status(testsuite_status, testsuite_impact, testsuite, ts_status_list,
+                   ts_impact_list):
+    """
+    This function computes the overall status
+    """
+    runmode, _, _ = \
+        common_execution_utils.get_runmode_from_xmlfile(testsuite)
+    if runmode is None:
+        ts_status_list.append(testsuite_status)
+        ts_impact_list.append(testsuite_impact)
+    elif runmode.upper() == "RMT":
+        ts_status_list.append(testsuite_status)
+        ts_impact_list.append(testsuite_impact)
+    elif runmode.upper() == "RUP":
+        if testsuite.find('runmode').get('status') is None or \
+           testsuite.find('runmode').get('status') == "":
+            ts_status_list.append(testsuite_status)
+            ts_impact_list.append(testsuite_impact)
+        elif testsuite.find('runmode').get('status') == 'last_instance' or \
+             testsuite.find('runmode').get('status') == 'expected':
+                if testsuite_status is True or \
+                  (testsuite.find('runmode').get('attempt') ==
+                   testsuite.find('runmode').get('runmode_value')):
+                    ts_status_list.append(testsuite_status)
+                    ts_impact_list.append(testsuite_impact)
+    elif runmode.upper() == "RUF":
+        if testsuite.find('runmode').get('status') is None or \
+           testsuite.find('runmode').get('status') == "":
+            ts_status_list.append(testsuite_status)
+            ts_impact_list.append(testsuite_impact)
+        elif testsuite.find('runmode').get('status') == 'last_instance':
+            if testsuite_status is False or \
+              (testsuite.find('runmode').get('attempt') ==
+               testsuite.find('runmode').get('runmode_value')):
+                    ts_status_list.append(testsuite_status)
+                    ts_impact_list.append(testsuite_impact)
+        elif testsuite.find('runmode').get('status') == 'expected':
+            if testsuite_status is False:
+                ts_status_list.append(True)
+                ts_impact_list.append(testsuite_impact)
+            elif testsuite_status is not False and \
+                (testsuite.find('runmode').get('attempt') ==
+                 testsuite.find('runmode').get('runmode_value')):
+                    ts_status_list.append(False)
+                    ts_impact_list.append(testsuite_impact)
+    return ts_status_list, ts_impact_list
+
+
 def execute_sequential_testsuites(testsuite_list, project_repository,
                                   data_repository, auto_defects):
     """ Executes suites in a project sequentially """
@@ -146,8 +194,8 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
             print_error("unexpected testsuite status, default to exception")
             data_repository['testsuite_%d_result' % suite_cntr] = "ERROR"
 
-        ts_status_list.append(testsuite_status)
-        ts_impact_list.append(testsuite_impact)
+        ts_status_list, ts_impact_list = compute_status(testsuite_status, testsuite_impact,
+                                                        testsuite, ts_status_list, ts_impact_list)
         if testsuite_impact.upper() == 'IMPACT':
             msg = "Status of the executed test suite impacts Project result"
         elif testsuite_impact.upper() == 'NOIMPACT':

--- a/warrior/WarriorCore/testcase_driver.py
+++ b/warrior/WarriorCore/testcase_driver.py
@@ -240,6 +240,7 @@ def get_steps_list(testcase_filepath):
                     copy_step = copy.deepcopy(step)
                     copy_step.find("runmode").set("value", go_next)
                     copy_step.find("runmode").set("attempt", i+1)
+                    copy_step.find("runmode").set("runmode_value", value)
                     step_list.append(copy_step)
             if retry_type is not None and retry_value > 0:
                 go_next = len(step_list) + retry_value + 1

--- a/warrior/WarriorCore/testcase_steps_execution.py
+++ b/warrior/WarriorCore/testcase_steps_execution.py
@@ -234,7 +234,8 @@ class TestCaseStepsExecutionClass(object):
 
         impact_dict = {"IMPACT": "Impact", "NOIMPACT": "No Impact"}
         self.data_repository['wt_junit_object']. \
-            add_keyword_result(self.data_repository['wt_tc_timestamp'], self.current_step_number, keyword, "SKIPPED",
+            add_keyword_result(self.data_repository['wt_tc_timestamp'],
+                               self.current_step_number, keyword, "SKIPPED",
                                kw_start_time, "0", "skipped",
                                impact_dict.get(step_impact.upper()), "N/A", step_description)
         self.data_repository['step_{}_result'.format(self.current_step_number)] = "SKIPPED"
@@ -376,7 +377,8 @@ def execute_steps(step_list, data_repository, system_name, parallel, queue, skip
     if step_num is None:
         step_num = 0
         while step_num < len(step_list):
-            step_num, goto_stepnum, do_continue = tc_step_exec_obj.execute_step(step_num, goto_stepnum)
+            step_num, goto_stepnum, do_continue = tc_step_exec_obj.execute_step(step_num,
+                                                                                goto_stepnum)
             if do_continue == "break":
                 break
     else:
@@ -407,5 +409,6 @@ def execute_steps(step_list, data_repository, system_name, parallel, queue, skip
 
 def main(step_list, data_repository, system_name=None, parallel=False, queue=False):
     """ Executes a testcase """
-    steps_execution_status = execute_steps(step_list, data_repository, system_name, parallel, queue)
+    steps_execution_status = execute_steps(step_list, data_repository,
+                                           system_name, parallel, queue)
     return steps_execution_status

--- a/warrior/WarriorCore/testcase_steps_execution.py
+++ b/warrior/WarriorCore/testcase_steps_execution.py
@@ -145,51 +145,6 @@ class TestCaseStepsExecutionClass(object):
             self.current_step_number = int(self.current_triggered_action) - 1
         return self.current_step_number, self.go_to_step_number, "continue"
 
-    def compute_status(self, step_status, step_impact):
-        """
-        This function computes the overall status
-        """
-        runmode, _, _ = \
-            common_execution_utils.get_runmode_from_xmlfile(self.current_step)
-        if runmode is None:
-            self.step_status_list.append(step_status)
-            self.step_impact_list.append(step_impact)
-        elif runmode.upper() == "RMT":
-            self.step_status_list.append(step_status)
-            self.step_impact_list.append(step_impact)
-        elif runmode.upper() == "RUP":
-            if self.current_step.find('runmode').get('status') is None or \
-               self.current_step.find('runmode').get('status') == "":
-                self.step_status_list.append(step_status)
-                self.step_impact_list.append(step_impact)
-            elif self.current_step.find('runmode').get('status') == 'last_instance' or \
-                 self.current_step.find('runmode').get('status') == 'expected':
-                    if step_status is True or \
-                      (self.current_step.find('runmode').get('attempt') ==
-                       self.current_step.find('runmode').get('runmode_value')):
-                        self.step_status_list.append(step_status)
-                        self.step_impact_list.append(step_impact)
-        elif runmode.upper() == "RUF":
-            if self.current_step.find('runmode').get('status') is None or \
-               self.current_step.find('runmode').get('status') == "":
-                self.step_status_list.append(step_status)
-                self.step_impact_list.append(step_impact)
-            elif self.current_step.find('runmode').get('status') == 'last_instance':
-                if step_status is False or \
-                  (self.current_step.find('runmode').get('attempt') ==
-                   self.current_step.find('runmode').get('runmode_value')):
-                        self.step_status_list.append(step_status)
-                        self.step_impact_list.append(step_impact)
-            elif self.current_step.find('runmode').get('status') == 'expected':
-                if step_status is False:
-                    self.step_status_list.append(True)
-                    self.step_impact_list.append(step_impact)
-                elif step_status is not False and \
-                    (self.current_step.find('runmode').get('attempt') ==
-                     self.current_step.find('runmode').get('runmode_value')):
-                        self.step_status_list.append(False)
-                        self.step_impact_list.append(step_impact)
-
     def _execute_current_step(self):
         """
         This function actually executes a given step and returns necessary details about that step.
@@ -208,7 +163,11 @@ class TestCaseStepsExecutionClass(object):
             step_impact = Utils.testcase_Utils.get_impact_from_xmlfile(self.current_step)
             print_error('unexpected error {0}'.format(traceback.format_exc()))
         self.go_to_step_number = False
-        self.compute_status(step_status, step_impact)
+        self.step_status_list, self.step_impact_list = \
+            common_execution_utils.compute_status(self.current_step,
+                                                  self.step_status_list,
+                                                  self.step_impact_list,
+                                                  step_status, step_impact)
         self.kw_resultfile_list.append(kw_resultfile)
         return step_status
 

--- a/warrior/WarriorCore/testsuite_driver.py
+++ b/warrior/WarriorCore/testsuite_driver.py
@@ -214,12 +214,14 @@ def get_testcase_list(testsuite_filepath):
                         copy_tc = copy.deepcopy(tc)
                         copy_tc.find("runmode").set("value", go_next)
                         copy_tc.find("runmode").set("attempt", i+1)
+                        copy_tc.find("runmode").set("runmode_value", value)
                         testcase_list.append(copy_tc)
                 # only one step in step list, append new step
                 else:
                     for i in range(0, value):
                         copy_tc = copy.deepcopy(tc)
                         copy_tc.find("runmode").set("attempt", i+1)
+                        copy_tc.find("runmode").set("runmode_value", value)
                         testcase_list.append(tc)
             if retry_type is not None and retry_value > 0:
                 if len(new_testcase_list) > 1:

--- a/wftests/warrior_tests/projects/pj_runmode_tests.xml
+++ b/wftests/warrior_tests/projects/pj_runmode_tests.xml
@@ -20,12 +20,12 @@
         <Testsuite>
             <path>../suites/framework_tests/runmode_tests/ts_runmode_rup_at_ts_local_level.xml</path>
             <onError action="next" value=""/>
-            <impact>noimpact</impact>
+            <impact>impact</impact>
         </Testsuite>
         <Testsuite>
             <path>../suites/framework_tests/runmode_tests/ts_runmode_ruf_at_ts_local_level.xml</path>
             <onError action="next" value=""/>
-            <impact>noimpact</impact>
+            <impact>impact</impact>
         </Testsuite>
 
         <!-- verify runmode at suite global level -->
@@ -59,32 +59,6 @@
             <impact>impact</impact>
         </Testsuite>
 
- <!-- runmode at project local level  -->
-        <Testsuite>
-            <path>../suites/framework_tests/runmode_tests/ts_runmode_rmt_at_pj_local_level.xml</path>
-            <onError action="next" value=""/>
-	    <runmode type="RMT" value="3"/>
-            <impact>noimpact</impact>
-        </Testsuite>
-        <Testsuite>
-            <path>../suites/framework_tests/runmode_tests/ts_runmode_rup_at_pj_local_level.xml</path>
-            <onError action="next" value=""/>
-	    <runmode type="RUP" value="7"/>
-            <impact>noimpact</impact>
-        </Testsuite>
-        <Testsuite>
-            <path>../suites/framework_tests/runmode_tests/ts_runmode_ruf_at_pj_local_level.xml</path>
-            <onError action="next" value=""/>
-	    <runmode type="RUF" value="7"/>
-            <impact>noimpact</impact>
-        </Testsuite>
-
-        <!-- verify runmode at project global level -->
-        <Testsuite>
-            <path>../suites/framework_tests/runmode_tests/ts_runmode_verify_at_pj_local_level.xml</path>
-            <onError action="next" value=""/>
-            <impact>impact</impact> 
-        </Testsuite>
 
 <!-- runmode at case local level -->
         <Testsuite>

--- a/wftests/warrior_tests/projects/pj_runmode_tests.xml
+++ b/wftests/warrior_tests/projects/pj_runmode_tests.xml
@@ -39,12 +39,12 @@
         <Testsuite>
             <path>../suites/framework_tests/runmode_tests/ts_runmode_rmt_at_ts_global_level_with_new_tag.xml</path>
             <onError action="next" value=""/>
-            <impact>impact</impact>
+            <impact>noimpact</impact>
         </Testsuite>
         <Testsuite>
             <path>../suites/framework_tests/runmode_tests/ts_runmode_rup_at_ts_global_level_with_new_tag.xml</path>
             <onError action="next" value=""/>
-            <impact>impact</impact>
+            <impact>noimpact</impact>
         </Testsuite>
         <Testsuite>
             <path>../suites/framework_tests/runmode_tests/ts_runmode_ruf_at_ts_global_level_with_new_tag.xml</path>

--- a/wftests/warrior_tests/projects/pj_runmode_tests_at_project_local_level.xml
+++ b/wftests/warrior_tests/projects/pj_runmode_tests_at_project_local_level.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" ?>
+<Project>
+    <Details>
+        <Name>pj_runmode_at_project_local_file</Name>
+        <Title>Project for testing runmode tag project local level</Title>
+        <Engineer>Warrior_user</Engineer>
+        <State>New</State>
+        <Date>07-18-2018</Date>
+        <Time>11:59:51</Time>
+        <default_onError action="next"/>
+    </Details>
+    <Testsuites> 
+<!-- runmode at project local level  -->
+     <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_rmt_at_pj_local_level.xml</path>
+            <onError action="next" value=""/>
+	    <runmode type="RMT" value="3"/>
+            <impact>noimpact</impact>
+        </Testsuite>
+	 <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_rmt_at_pj_local_level_with_status.xml</path>
+            <onError action="next" value=""/>
+	    <runmode type="RMT" value="2" status=""/>
+            <impact>noimpact</impact>
+        </Testsuite>
+      <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_rup_at_pj_local_level.xml</path>
+            <onError action="next" value=""/>
+	    <runmode type="RUP" value="7"/>
+            <impact>noimpact</impact>
+        </Testsuite>  
+	  <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_rup_at_pj_local_level_with_last_instance.xml</path>
+            <onError action="next" value=""/>
+	    <runmode type="RUP" value="4" status="last_instance"/>
+            <impact>impact</impact>
+        </Testsuite> 
+	  <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_rup_at_pj_local_level_with_expected.xml</path>
+            <onError action="next" value=""/>
+	    <runmode type="RUP" value="4" status="expected"/>
+            <impact>impact</impact> 
+        </Testsuite> 
+         <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_ruf_at_pj_local_level.xml</path>
+            <onError action="next" value=""/>
+	    <runmode type="RUF" value="7"/>
+            <impact>noimpact</impact>
+        </Testsuite> 
+	  <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_ruf_at_pj_local_level_with_last_instance.xml</path>
+            <onError action="next" value=""/>
+	    <runmode type="RUF" value="4" status="last_instance"/>
+            <impact>noimpact</impact>
+        </Testsuite>
+	 <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_ruf_at_pj_local_level_with_expected.xml</path>
+            <onError action="next" value=""/>
+	    <runmode type="RUF" value="4" status="expected"/>
+            <impact>impact</impact>
+        </Testsuite> 
+
+        <!-- verify runmode at project global level -->
+      <Testsuite>
+            <path>../suites/framework_tests/runmode_tests/ts_runmode_verify_at_pj_local_level.xml</path>
+            <onError action="next" value=""/>
+            <impact>impact</impact> 
+        </Testsuite> 
+   </Testsuites>
+</Project>
+

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rmt_at_pj_local_level_with_status.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rmt_at_pj_local_level_with_status.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_rmt_at_pj_local_level</Name>
+                <Title>test suite to run runmode(RMT) at project file local section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:37:26</Time>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_pj_local_level_with_status.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rmt_at_ts_local_level.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rmt_at_ts_local_level.xml
@@ -22,5 +22,13 @@
                         <onError action="next"/>
                         <impact>impact</impact>
                 </Testcase>
+		  <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_ts_local_level_with_status.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+			<runmode type="RMT" value="4" status=""/>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
         </Testcases>
 </TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_ruf_at_pj_local_level_with_expected.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_ruf_at_pj_local_level_with_expected.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_ruf_at_pj_local_level-expected</Name>
+                <Title>test suite to run runmode(RUF) at project file local section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:37:26</Time>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_pj_local_level_with_expected.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_ruf_at_pj_local_level_with_last_instance.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_ruf_at_pj_local_level_with_last_instance.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_ruf_at_pj_local_level-last_instance</Name>
+                <Title>test suite to run runmode(RUF) at project file local section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:37:26</Time>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_pj_local_level_with_last_instance.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_ruf_at_ts_local_level.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_ruf_at_ts_local_level.xml
@@ -14,12 +14,28 @@
                 <Requirement>Requirement-002</Requirement>
         </Requirements>
         <Testcases>
-                <Testcase>
+             <Testcase>
                         <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_ts_local_level.xml</path>
                         <context>positive</context>
                         <runtype>sequential_keywords</runtype>
                         <onError action="next"/>
 			<runmode type="RUF" value="7"/>
+                        <impact>noimpact</impact>
+                </Testcase>
+		<Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_ts_local_level_with_last_instance.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+			<runmode type="RUF" value="4" status="last_instance"/>
+                        <impact>noimpact</impact>
+                </Testcase> 
+		 <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_ts_local_level_with_expected.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+			<runmode type="RUF" value="4" status="expected"/>
                         <impact>impact</impact>
                 </Testcase>
         </Testcases>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rup_at_pj_local_level_with_expected.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rup_at_pj_local_level_with_expected.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_rup_at_pj_local_level-expected</Name>
+                <Title>test suite to run runmode(RUP) at project file section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:37:26</Time>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_rup_at_pj_local_level_with_expected.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rup_at_pj_local_level_with_last_instance.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rup_at_pj_local_level_with_last_instance.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_runmode_rup_at_pj_local_level-last_instance</Name>
+                <Title>test suite to run runmode(RUP) at project file section</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>07-18-2018</Date>
+                <Time>11:37:26</Time>
+                <default_onError action="next"/>
+                <Resultsdir/>
+        </Details>
+        <Requirements>
+                <Requirement>Requirement-001</Requirement>
+                <Requirement>Requirement-002</Requirement>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_rup_at_pj_local_level_with_last_instance.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rup_at_ts_local_level.xml
+++ b/wftests/warrior_tests/suites/framework_tests/runmode_tests/ts_runmode_rup_at_ts_local_level.xml
@@ -14,12 +14,28 @@
                 <Requirement>Requirement-002</Requirement>
         </Requirements>
         <Testcases>
-                <Testcase>
+               <Testcase>
                         <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_rup_at_ts_local_level.xml</path>
                         <context>positive</context>
                         <runtype>sequential_keywords</runtype>
                         <onError action="next"/>
 			<runmode type="RUP" value="7"/>
+                        <impact>noimpact</impact>
+                </Testcase> 
+		 <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_rup_at_ts_local_level_with_last_instance.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+			<runmode type="RUP" value="4" status="last_instance"/>
+                        <impact>impact</impact>
+                </Testcase>
+		 <Testcase>
+                        <path>../../../testcases/framework_tests/runmode_tests/tc_runmode_rup_at_ts_local_level_with_expected.xml</path>
+                        <context>positive</context>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next"/>
+			<runmode type="RUP" value="4" status="expected"/>
                         <impact>impact</impact>
                 </Testcase>
         </Testcases>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_pj_local_level_with_status.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_pj_local_level_with_status.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_rmt_at_pj_local_level_with_status</Name>
+                <Title>Test the runmode functionality specified at project file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="pj_rmt_count_local_status"/>
+                                <argument name="status" value="fail"/>
+                                <argument name="max_value" value="2"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_tc_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_tc_local_level.xml
@@ -7,10 +7,10 @@
                 <default_onError action="next"/>
                 <Logsdir>../../../Execution</Logsdir>
                 <Resultsdir>../../../Execution</Resultsdir>
-                <Date>07-18-2018</Date>
+                <Date>2017-10-31</Date>
                 <InputDataFile>No_Data</InputDataFile>
                 <Time>11:34</Time>
-                <Engineer>Warrior_user</Engineer>
+                <Engineer>Warrior</Engineer>
         </Details>
         <Requirements>
                 <Requirement/>
@@ -36,6 +36,35 @@
                                 <argument name="comparison" value="eq"/>
                                 <argument name="type" value="int"/>
                                 <argument name="object_key" value="tc_rmt"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description/>
+                        <iteration_type type=""/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+                </step>
+		<step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="tc_rmt_status"/>
+                                <argument name="status" value="pass"/>
+                                <argument name="max_value" value="2"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+			<runmode type="RMT" value="2" status=""/>
+                        <impact>impact</impact>
+                </step>
+		<step Driver="common_driver" Keyword="verify_data" TS="2" draft="no">
+                        <Arguments>
+                                <argument name="expected" value="2"/>
+                                <argument name="comparison" value="eq"/>
+                                <argument name="type" value="int"/>
+                                <argument name="object_key" value="tc_rmt_status"/>
                         </Arguments>
                         <Execute ExecType="Yes"/>
                         <onError action="next"/>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_ts_local_level_with_status.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rmt_at_ts_local_level_with_status.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_rmt_at_ts_local_level with status</Name>
+                <Title>Test the runmode functionality specified at testsuite file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="ts_rmt_count_local_status"/>
+                                <argument name="status" value="pass"/>
+                                <argument name="max_value" value="4"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_pj_local_level_with_expected.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_pj_local_level_with_expected.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_ruf_at_pj_local_level-expected</Name>
+                <Title>Test the runmode functionality specified at project file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="pj_ruf_count_local_exp"/>
+                                <argument name="status" value="pass"/>
+                                <argument name="max_value" value="2"/>
+                                <argument name="max_status" value="fail"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_pj_local_level_with_last_instance.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_pj_local_level_with_last_instance.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_ruf_at_pj_local_level-last_instance</Name>
+                <Title>Test the runmode functionality specified at project file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="pj_ruf_count_local_ls"/>
+                                <argument name="status" value="pass"/>
+                                <argument name="max_value" value="2"/>
+                                <argument name="max_status" value="fail"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_tc_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_tc_local_level.xml
@@ -7,16 +7,16 @@
                 <default_onError action="next"/>
                 <Logsdir>../../../Execution</Logsdir>
                 <Resultsdir>../../../Execution</Resultsdir>
-                <Date>07-18-2018</Date>
+                <Date>2017-10-31</Date>
                 <InputDataFile>No_Data</InputDataFile>
                 <Time>11:34</Time>
-                <Engineer>Warrior_user</Engineer>
+                <Engineer>Warrior</Engineer>
         </Details>
         <Requirements>
                 <Requirement/>
         </Requirements>
         <Steps>
-                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="1">
                         <Arguments>
                                 <argument name="key" value="tc_ruf"/>
                                 <argument name="status" value="pass"/>
@@ -36,6 +36,93 @@
                                 <argument name="comparison" value="eq"/>
                                 <argument name="type" value="int"/>
                                 <argument name="object_key" value="tc_ruf"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description/>
+                        <iteration_type type=""/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+               </step>
+	       <step Driver="ci_regression_driver" Keyword="increase_value" TS="3">
+                        <Arguments>
+                                <argument name="key" value="tc_ruf_status_1"/>
+                                <argument name="status" value="pass"/>
+                                <argument name="max_value" value="2"/>
+                                <argument name="max_status" value="fail"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+			<runmode type="RUF" value="4" status="last_instance"/>
+                        <impact>noimpact</impact>
+                </step>
+		 <step Driver="common_driver" Keyword="verify_data" TS="4" draft="no">
+                        <Arguments>
+                                <argument name="expected" value="2"/>
+                                <argument name="comparison" value="eq"/>
+                                <argument name="type" value="int"/>
+                                <argument name="object_key" value="tc_ruf_status_1"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description/>
+                        <iteration_type type=""/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+               </step>
+		  <step Driver="ci_regression_driver" Keyword="increase_value" TS="5">
+                        <Arguments>
+                                <argument name="key" value="tc_ruf_status_2"/>
+                                <argument name="status" value="pass"/>
+                                <argument name="max_value" value="4"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+			<runmode type="RUF" value="4" status="last_instance"/>
+                        <impact>noimpact</impact>
+                </step>
+		 <step Driver="common_driver" Keyword="verify_data" TS="8" draft="no">
+                        <Arguments>
+                                <argument name="expected" value="4"/>
+                                <argument name="comparison" value="eq"/>
+                                <argument name="type" value="int"/>
+                                <argument name="object_key" value="tc_ruf_status_2"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description/>
+                        <iteration_type type=""/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+               </step>
+		 <step Driver="ci_regression_driver" Keyword="increase_value" TS="9">
+                        <Arguments>
+                                <argument name="key" value="tc_ruf_status_3"/>
+                                <argument name="status" value="pass"/>
+                                <argument name="max_value" value="2"/>
+                                <argument name="max_status" value="fail"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+			<runmode type="RUF" value="4" status="expected"/>
+                        <impact>impact</impact>
+                </step>
+		 <step Driver="common_driver" Keyword="verify_data" TS="11" draft="no">
+                        <Arguments>
+                                <argument name="expected" value="2"/>
+                                <argument name="comparison" value="eq"/>
+                                <argument name="type" value="int"/>
+                                <argument name="object_key" value="tc_ruf_status_3"/>
                         </Arguments>
                         <Execute ExecType="Yes"/>
                         <onError action="next"/>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_ts_local_level_with_expected.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_ts_local_level_with_expected.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_ruf_at_ts_local_level-expected status</Name>
+                <Title>Test the runmode functionality specified at testsuite file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="ts_ruf_count_local_exp"/>
+                                <argument name="status" value="pass"/>
+                                <argument name="max_value" value="2"/>
+                                <argument name="max_status" value="fail"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_ts_local_level_with_last_instance.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_ruf_at_ts_local_level_with_last_instance.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_ruf_at_ts_local_level-last_instance</Name>
+                <Title>Test the runmode functionality specified at testsuite file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="ts_ruf_count_local_ls"/>
+                                <argument name="status" value="pass"/>
+                                <argument name="max_value" value="2"/>
+                                <argument name="max_status" value="fail"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_pj_local_level_with_expected.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_pj_local_level_with_expected.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_rup_at_pj_local_level-expected</Name>
+                <Title>Test the runmode functionality specified at project file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="pj_rup_count_local_exp"/>
+                                <argument name="status" value="fail"/>
+                                <argument name="max_value" value="2"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_pj_local_level_with_last_instance.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_pj_local_level_with_last_instance.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_rup_at_pj_local_level-last_instance</Name>
+                <Title>Test the runmode functionality specified at project file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="pj_rup_count_local_ls"/>
+                                <argument name="status" value="fail"/>
+                                <argument name="max_value" value="2"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_tc_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_tc_local_level.xml
@@ -7,16 +7,16 @@
                 <default_onError action="next"/>
                 <Logsdir>../../../Execution</Logsdir>
                 <Resultsdir>../../../Execution</Resultsdir>
-                <Date>07-18-2018</Date>
+                <Date>2017-10-31</Date>
                 <InputDataFile>No_Data</InputDataFile>
                 <Time>11:34</Time>
-                <Engineer>Warrior_user</Engineer>
+                <Engineer>Warrior</Engineer>
         </Details>
         <Requirements>
                 <Requirement/>
         </Requirements>
         <Steps>
-                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="1">
                         <Arguments>
                                 <argument name="key" value="tc_rup"/>
                                 <argument name="status" value="fail"/>
@@ -36,6 +36,64 @@
                                 <argument name="comparison" value="eq"/>
                                 <argument name="type" value="int"/>
                                 <argument name="object_key" value="tc_rup"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description/>
+                        <iteration_type type=""/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+                </step>
+		 <step Driver="ci_regression_driver" Keyword="increase_value" TS="3">
+                        <Arguments>
+                                <argument name="key" value="tc_rup_status_1"/>
+                                <argument name="status" value="fail"/>
+                                <argument name="max_value" value="2"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+			<runmode type="RUP" value="4" status="last_instance"/>
+                        <impact>impact</impact>
+	      </step>
+	      <step Driver="common_driver" Keyword="verify_data" TS="4" draft="no">
+                        <Arguments>
+                                <argument name="expected" value="2"/>
+                                <argument name="comparison" value="eq"/>
+                                <argument name="type" value="int"/>
+                                <argument name="object_key" value="tc_rup_status_1"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description/>
+                        <iteration_type type=""/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+                </step>
+		 <step Driver="ci_regression_driver" Keyword="increase_value" TS="5">
+                        <Arguments>
+                                <argument name="key" value="tc_rup_status_2"/>
+                                <argument name="status" value="fail"/>
+                                <argument name="max_value" value="2"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+			<runmode type="RUP" value="4" status="expected"/>
+                        <impact>impact</impact>
+	      </step>
+	      <step Driver="common_driver" Keyword="verify_data" TS="6" draft="no">
+                        <Arguments>
+                                <argument name="expected" value="2"/>
+                                <argument name="comparison" value="eq"/>
+                                <argument name="type" value="int"/>
+                                <argument name="object_key" value="tc_rup_status_2"/>
                         </Arguments>
                         <Execute ExecType="Yes"/>
                         <onError action="next"/>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_ts_local_level_with_expected.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_ts_local_level_with_expected.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_rup_at_ts_local_level - expected status</Name>
+                <Title>Test the runmode functionality specified at testsuite file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="ts_rup_count_local_exp"/>
+                                <argument name="status" value="fail"/>
+                                <argument name="max_value" value="2"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_ts_local_level_with_last_instance.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_rup_at_ts_local_level_with_last_instance.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_runmode_rup_at_ts_local_level - last_instance</Name>
+                <Title>Test the runmode functionality specified at testsuite file local section</Title>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir>../../../Execution</Logsdir>
+                <Resultsdir>../../../Execution</Resultsdir>
+                <Date>07-18-2018</Date>
+                <InputDataFile>No_Data</InputDataFile>
+                <Time>11:34</Time>
+                <Engineer>Warrior_user</Engineer>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="increase_value" TS="2">
+                        <Arguments>
+                                <argument name="key" value="ts_rup_count_local_ls"/>
+                                <argument name="status" value="fail"/>
+                                <argument name="max_value" value="2"/>
+                                <argument name="max_status" value="pass"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_verify_at_pj_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_verify_at_pj_local_level.xml
@@ -28,6 +28,18 @@
                         <context>positive</context>
                         <impact>impact</impact>
                 </step>
+		 <step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="2"/>
+                                <argument name="object_key" value="pj_rmt_count_local_status"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
                 <step Driver="common_driver" Keyword="verify_data" TS="1">
                         <Arguments>
                                 <argument name="expected" value="4"/>
@@ -40,10 +52,58 @@
                         <context>positive</context>
                         <impact>impact</impact>
                 </step>
+		<step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="2"/>
+                                <argument name="object_key" value="pj_rup_count_local_ls"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+		<step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="2"/>
+                                <argument name="object_key" value="pj_rup_count_local_exp"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
                 <step Driver="common_driver" Keyword="verify_data" TS="1">
                         <Arguments>
                                 <argument name="expected" value="5"/>
                                 <argument name="object_key" value="pj_ruf_count_local"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+		<step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="2"/>
+                                <argument name="object_key" value="pj_ruf_count_local_ls"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+	        <step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="2"/>
+                                <argument name="object_key" value="pj_ruf_count_local_exp"/>
                                 <argument name="type" value="int"/>
                         </Arguments>
                         <onError action="next"/>

--- a/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_verify_at_ts_local_level.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/runmode_tests/tc_runmode_verify_at_ts_local_level.xml
@@ -28,6 +28,18 @@
                         <context>positive</context>
                         <impact>impact</impact>
                 </step>
+		<step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="4"/>
+                                <argument name="object_key" value="ts_rmt_count_local_status"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
                 <step Driver="common_driver" Keyword="verify_data" TS="1">
                         <Arguments>
                                 <argument name="expected" value="4"/>
@@ -40,10 +52,58 @@
                         <context>positive</context>
                         <impact>impact</impact>
                 </step>
+		<step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="2"/>
+                                <argument name="object_key" value="ts_rup_count_local_ls"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+       		<step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="2"/>
+                                <argument name="object_key" value="ts_rup_count_local_exp"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
                 <step Driver="common_driver" Keyword="verify_data" TS="1">
                         <Arguments>
                                 <argument name="expected" value="5"/>
                                 <argument name="object_key" value="ts_ruf_count_local"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+		   <step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="2"/>
+                                <argument name="object_key" value="ts_ruf_count_local_ls"/>
+                                <argument name="type" value="int"/>
+                        </Arguments>
+                        <onError action="next"/>
+                        <Description></Description>
+                        <Execute ExecType="Yes"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                </step>
+		   <step Driver="common_driver" Keyword="verify_data" TS="1">
+                        <Arguments>
+                                <argument name="expected" value="2"/>
+                                <argument name="object_key" value="ts_ruf_count_local_exp"/>
                                 <argument name="type" value="int"/>
                         </Arguments>
                         <onError action="next"/>


### PR DESCRIPTION
Requirement:
User needs a way compute the final status of a Case/Suite/Project in runmode execution.

Fix Explanation:
1. If the runmode type is RMT, if a failure occurs in any of the attempts, the overall status is marked as a FAIL. (existing way)
2. If runmode type is RUP or RUF, a new attribute named "status" is introduced in runmode tag to compute status, which takes in two values namely,
    - "last_instance" >> The overall status is the status of the last instance(last attempt)
    - "expected"  >> For RUP, if there is a PASS , the overall result is PASS. For RUF, if there is a FAIL 
                               attempt, the overall result is PASS as the failure is a expected one in this case.
3. If the status attribute is left empty or not provided in RUP or RUF, it behaves in the existing way(default) i.e, if any one of the attempts FAIL, the overall status is marked as FAIL.

Added the Regression Logs and Instructions for testing in Jira.