### PR TITLE
WAR-1858: Suite status with runmode in suite global level, reflects the status of the last attempted case

### DIFF
--- a/warrior/WarriorCore/common_execution_utils.py
+++ b/warrior/WarriorCore/common_execution_utils.py
@@ -224,3 +224,36 @@ def get_retry_from_xmlfile(element):
                           "using default value 5 for execution")
         retry_value = int(retry_value)
     return (retry_type, retry_cond, retry_cond_value, retry_value, retry_interval)
+
+
+def compute_runmode_status(global_status_list, runmode, global_xml):
+    if global_xml.find('runmode').get('status') == None or \
+        global_xml.find('runmode').get('status') == "" or \
+            runmode.upper() == "RMT":
+        if "FALSE" in global_status_list or False in global_status_list:
+            status_value = False
+        elif "RAN" in global_status_list:
+            status_value = "RAN"
+        elif "ERROR" in global_status_list:
+            status_value = "ERROR"
+        else:
+            status_value = True
+    elif runmode.upper() == "RUP":
+        if global_xml.find('runmode').get('status') == 'last_instance':
+            status_value = global_status_list.pop()
+        elif global_xml.find('runmode').get('status') == 'expected' and \
+                (global_status_list.pop() == True or
+                 global_status_list.pop() == "TRUE"):
+            status_value = True
+        else:
+            status_value = global_status_list.pop()
+    elif runmode.upper() == "RUF":
+        if global_xml.find('runmode').get('status') == 'last_instance':
+            status_value = global_status_list.pop()
+        elif global_xml.find('runmode').get('status') == 'expected' and \
+                (global_status_list.pop() == False or
+                 global_status_list.pop() == "FALSE"):
+            status_value = True
+        else:
+            status_value = global_status_list.pop()
+    return status_value

--- a/warrior/WarriorCore/testsuite_driver.py
+++ b/warrior/WarriorCore/testsuite_driver.py
@@ -192,6 +192,7 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
                               execution directory will be created (results for the testsuite will
                               be stored in the  testsuite execution directory.)
     """
+    testsuite_status_list = []
     suite_start_time = Utils.datetime_utils.get_current_timestamp()
     print_info("[{0}] Testsuite execution starts".format(suite_start_time))
     initialize_suite_fields(data_repository)
@@ -308,6 +309,7 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
                                                                     data_repository, from_project,
                                                                     auto_defects=auto_defects)
                 test_count = i * len(testcase_list)
+                testsuite_status_list.append(test_suite_status)
                 testsuite_utils.pSuite_update_suite_tests(str(test_count))
                 if str(test_suite_status).upper() == "FALSE" or\
                    str(test_suite_status).upper() == "ERROR":
@@ -323,6 +325,7 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
                                                                     data_repository, from_project,
                                                                     auto_defects=auto_defects)
                 test_count = i * len(testcase_list)
+                testsuite_status_list.append(test_suite_status)
                 testsuite_utils.pSuite_update_suite_tests(str(test_count))
                 if str(test_suite_status).upper() == "TRUE":
                     break
@@ -337,7 +340,11 @@ def execute_testsuite(testsuite_filepath, data_repository, from_project,
                 test_suite_status = sequential_testcase_driver.main(testcase_list, suite_repository,
                                                                     data_repository, from_project,
                                                                     auto_defects=auto_defects)
-
+                testsuite_status_list.append(test_suite_status)
+        if runmode is not None:
+            test_suite_status = common_execution_utils.compute_runmode_status(
+                                                        testsuite_status_list,
+                                                        runmode, suite_global_xml)
     # The below runmode part is not modified/removed to preserve backward compatibility
     elif execution_type.upper() == 'RUN_UNTIL_FAIL' and runmode is None:
         execution_value = Utils.xml_Utils.getChildAttributebyParentTag(testsuite_filepath,


### PR DESCRIPTION
Issue:
In global level runmode, the overall status is the status of the last attempt of runmode execution. This is because, 'the test_suite_status' value is overwritten as runmode execution runs in loop

Fix Explanation:
Added a method 'compute_runmode_status' in common_execution_utils to implement the support below,
1. If the runmode type is RMT, if a failure occurs in any of the attempts, the overall status is marked as a 
    FAIL. (existing way)
2. If runmode type is RUP or RUF, a new attribute named "status" is introduced in runmode tag to 
    compute status, which takes in two values namely,
    - "last_instance" >> The overall status is the status of the last instance(last attempt)
    - "expected" >> For RUP, if there is a PASS , the overall result is PASS. For RUF, if there is a FAIL
                              attempt, the overall result is PASS as the failure is a expected one in this case.
3. If the status attribute is left empty or not provided in RUP or RUF, it behaves in the existing 
    way(default) i.e, if any one of the attempts FAIL, the overall status is marked as FAIL.

Added the regression logs and instruction for testing in Jira.